### PR TITLE
Cronjob to release on new tags

### DIFF
--- a/cron_tag_release.sh
+++ b/cron_tag_release.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -eu
+
+main=master
+
+RELEASE_DIR="/srv/http/domjudge/releases"
+DOWNLOAD_RELEASE_SCRIPT=""
+
+notify_channel () {
+    # Local debug
+    echo "$1"
+    # When cron is run often one should have time to
+    # fix the issue.
+    if [ ! -f /tmp/$2 ]; then
+        # Write to syslog on server
+        logger "$1"
+        DATA='{"text":"'"$1"'"}'
+        # Notify DOMjudge Slack channel (github-notifications)
+        # SLACK_URL should be exported in the .bashrc (it should be secret)
+        curl -X POST -H 'Content-type: application/json' --data "$DATA" "$SLACK_URL"
+        touch /tmp/$2
+    fi
+}
+
+process_tag () {
+    TAG="$1"
+    NUMB="[0-9]+"
+    DOT="\."
+    RELEASE="$NUMB$DOT$NUMB$DOT$NUMB"
+    OPTRC="((RC|rc)[0-9])?"
+    if [[ $TAG =~ ^$RELEASE$OPTRC$ ]]; then
+       # TODO: check if the file already exists
+       if [ -f "$RELEASE_DIR/domjudge-$TAG.tar.gz" ]; then
+           # Tag is already handled
+           return 0
+       fi
+       # To find the signer key of a earlier tag:
+       # gpg --search 780355B5EA6BFC8235A99C4B56F61A79401DAC04
+       # And if one trusts the internet to be correct
+       # gpg --recv-keys 780355B5EA6BFC8235A99C4B56F61A79401DAC04
+       set +e # Some tags are not signed
+       if git verify-tag $TAG; then
+           set -e
+           # At this point the tarball should already be locally tested
+           ~/domjudge-scripts/make_release.sh "$TAG"
+           mv domjudge-$TAG.* $RELEASE_DIR/
+           notify_channel "Tarball finished ($TAG)." "$TAG"
+       else
+           notify_channel "Untrusted tag ($TAG)" "$TAG"
+       fi
+    fi
+}
+
+# Reset to main branch
+cd ~domjudge/domjudge
+git checkout $main
+
+while read -r tag; do
+    #echo "Handling tag: $tag"
+    process_tag "$tag"
+done <<< "$(git tag)"
+

--- a/make_release.sh
+++ b/make_release.sh
@@ -3,12 +3,13 @@
 # Script to create a DOMjudge release package. Release file is
 # generated in the current directory.
 
-if [ -z "${CI+x}" ]; then
+CI_USAGE=${CI+x}
+if [ -z "$CI_USAGE" ]; then
     set -e
 else
     set -eux
     export PS4='(${0}:): - [$?] $ '
-fi
+fi 
 
 GITURL="https://github.com/DOMjudge/domjudge.git"
 
@@ -19,11 +20,11 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-if [ -n "${CI+x}" ]; then
+if [ -n "$CI_USAGE" ]; then
     set +x
 fi
 TAG="$1" ; shift
-if [ -n "${CI+x}" ]; then
+if [ -n "$CI_USAGE" ]; then
     set -x
 fi
 
@@ -53,6 +54,10 @@ CHLOG_VERSION="$(echo "$CHLOG" | sed -r 's/^Version ([0-9\.]+) .*$/\1/')"
 if [ "$VERSION" != "$CHLOG_VERSION" ]; then
     echo "WARNING: version strings in README* and ChangeLog differ:"
     echo "'$VERSION' != '$CHLOG_VERSION'"
+    if [ ! -t 1 && -z ${CI+x} ] ; then
+        # In the cronjob this would be reason to not release
+        exit 1
+    fi
 fi
 
 # Add released tag for revision information:
@@ -64,17 +69,17 @@ cd ..
 
 mv domjudge "domjudge-$VERSION"
 
-tar -cf "domjudge-$VERSION.tar" "domjudge-$VERSION"
-gzip -9 "domjudge-$VERSION.tar"
+tar -cf "domjudge-$TAG.tar" "domjudge-$VERSION"
+gzip -9 "domjudge-$TAG.tar"
 
 cd "$OWD"
 
-mv "$TEMPDIR/domjudge-$VERSION.tar.gz" .
+mv "$TEMPDIR/domjudge-$TAG.tar.gz" .
 rm -rf "$TEMPDIR"
 
-sha256sum "domjudge-$VERSION.tar.gz" > "domjudge-$VERSION.tar.gz.sha256sum"
+sha256sum "domjudge-$TAG.tar.gz" > "domjudge-$TAG.tar.gz.sha256sum"
 
-GPG_ARGS="-a --detach-sign --digest-algo SHA256 domjudge-$VERSION.tar.gz"
+GPG_ARGS="-a --detach-sign --digest-algo SHA256 domjudge-$TAG.tar.gz"
 if [ -t 1 ] ; then
     # Explicit not quoted!
     gpg $GPG_ARGS

--- a/new_release_howto.md
+++ b/new_release_howto.md
@@ -18,10 +18,17 @@ on the account `domjudge@vm-domjudge`):
     The tarball is placed in the current dir; check that it looks correct,
     test e.g. by unpacking it and running
         ./configure && make build
+ 1. Don't forget to push everything to the central Git repository
+    (especially the release tags, since these are not pushed by default),
+    e.g. with
+        `git push origin ${TAG%.?} refs/tags/$TAG`
+ 1. On the server the tarball will be rebuild and signed.
  1. If releasing from the master branch, create a new version branch:
-        git checkout -b x.y
-        git push --set-upstream origin x.y
-        git checkout master
+    ```{sh}
+    git checkout -b x.y
+    git push --set-upstream origin x.y
+    git checkout master
+    ```
  1. Update files above to `{version+1}DEV` and commit.
  1. Copy domjudge-$TAG.tar.gz* to `/srv/http/domjudge/releases/`
  1. Update the DOMjudge homepage: commit changes in the `domjudge-scripts`
@@ -32,8 +39,4 @@ on the account `domjudge@vm-domjudge`):
     The documentation is regenerated once every hour.
  1. Bump the docker containers and build Debian packages (or make someone
     do this).
- 1. Send an email to domjudge-announce@domjudge.org.
- 1. Don't forget to push everything to the central Git repository
-    (especially the release tags, since these are not pushed by default),
-    e.g. with
-        git push origin ${TAG%.?} refs/tags/$TAG
+ 1. Send an email to `domjudge-announce@domjudge.org`.


### PR DESCRIPTION
The last addition to the make_release is not needed anymore as
deployment is now done via the server.

- Setup extra environment variables
- Trigger tests on gitlab

- The server builds the tar.gz is built and signed
- We trigger a pipeline in domjudge-packaging (https://docs.gitlab.com/ee/ci/triggers/#triggering-a-pipeline)
  - This can test the build tar.gz, -> Suggested by @eldering to do before triggering
  - This can test the debs, -> Seems to react very different
  - This can build the dockers -> Manual trigger for now

Unclear:
- Where should the debs be build? -> Probably always manual

TODO:
- Do the website update step (future PR probably)

The reason that I prefer to do as much as possible on gitlab is that the logging in my opinion is easier to follow, but I'm also fine with doing more on the webserver.