### PR TITLE
Isolate the judge to the 2nd core

### DIFF
--- a/icpc-wf/ansible/roles/judgedaemon/handlers/main.yml
+++ b/icpc-wf/ansible/roles/judgedaemon/handlers/main.yml
@@ -11,7 +11,11 @@
   service: name=create-cgroups enabled=yes state=restarted
 
 - name: enable and restart judgedaemon
-  service: name=domjudge-judgehost enabled=yes state=restarted
+  service:
+    name="domjudge-judgedaemon@{{item}}"
+    enabled=yes
+    state=restarted
+  with_items: "{{CPUCORE}}"
 
 - name: update grub
   shell: update-grub

--- a/icpc-wf/ansible/roles/judgedaemon/tasks/main.yml
+++ b/icpc-wf/ansible/roles/judgedaemon/tasks/main.yml
@@ -2,12 +2,8 @@
 # These tasks configure the DOMjudge judgedaemon with chroot
 
 - name: create domjudge-run users
-  user: name={{item}} createhome=no home=/nonexistent group=nogroup shell=/bin/false
-  with_items:
-    - domjudge-run-0
-    - domjudge-run-1
-    - domjudge-run-2
-    - domjudge-run-3
+  user: name=domjudge-run-{{item}} createhome=no home=/nonexistent group=nogroup shell=/bin/false
+  with_items: "{{CPUCORE}}"
 
 - name: create domjudge-run group
   group: name=domjudge-run state=present
@@ -32,16 +28,20 @@
   args:
     creates: "/chroot/domjudge"
 
+- name: Pre-generate the kernel flags for ansible usage
+  set_fact:
+    procline: "cgroup_enable=memory swapaccount=1 isolcpus={{ CPUCORE|join(',') }}"
+
 - name: add cgroup kernel parameters
   lineinfile:
     dest: /etc/default/grub
     regexp: '^GRUB_CMDLINE_LINUX_DEFAULT='
-    line: 'GRUB_CMDLINE_LINUX_DEFAULT="quiet splash cgroup_enable=memory swapaccount=1"'
+    line: "{{ procline }}"
 
 - name: check cgroup kernel parameters
   command: cat /proc/cmdline
   register: kernel_cmdline
-  changed_when: "'cgroup_enable=memory swapaccount=1' not in kernel_cmdline.stdout"
+  changed_when: procline not in kernel_cmdline.stdout
   notify:
     - update grub
     - reboot
@@ -70,7 +70,7 @@
     dest: /etc/systemd/system/
   with_items:
     - create-cgroups
-    - domjudge-judgehost
+    - domjudge-judgedaemon@
   notify:
     - restart systemctl
     - enable and restart create-cgroups

--- a/icpc-wf/ansible/roles/judgedaemon/vars/main.yml
+++ b/icpc-wf/ansible/roles/judgedaemon/vars/main.yml
@@ -1,0 +1,5 @@
+CPUCORE:
+  - 2
+# Add additional CPU cores to pin judgedaemons on as:
+# - 3
+# - 4


### PR DESCRIPTION
Assuming the hyperthreading core is always at the *n*%2==1 core, and the kernel uses cpu(0) this is the next safe bet. The run users are removed as at the WF the judges typicly only run with 1 judgedaemon.

I'll still need to test this, but this is to start the implementation. This closes https://github.com/DOMjudge/domjudge-scripts/issues/15