### PR TITLE
Contest api updates

### DIFF
--- a/contest-api/check-api.sh
+++ b/contest-api/check-api.sh
@@ -22,6 +22,7 @@ judgements
 runs
 clarifications
 awards
+commentary
 scoreboard
 '
 
@@ -30,6 +31,7 @@ scoreboard
 ENDPOINTS_OPTIONAL='
 team-members
 awards
+commentary
 '
 
 ENDPOINTS_TO_FAIL='

--- a/contest-api/json-schema/award.json
+++ b/contest-api/json-schema/award.json
@@ -7,11 +7,7 @@
 	"properties": {
 		"id": { "$ref": "common.json#/identifier" },
 		"citation": { "type": "string" },
-		"team_ids": {
-			"type": "array",
-			"uniqueItems": true,
-			"items": { "$ref": "common.json#/identifier" }
-		}
+		"team_ids": { "$ref": "common.json#/identifiers" }
 	},
 	"required": ["id", "citation", "team_ids"],
 	"$ref": "common.json#/strictproperties"

--- a/contest-api/json-schema/clarification.json
+++ b/contest-api/json-schema/clarification.json
@@ -11,8 +11,6 @@
 		"reply_to_id": { "$ref": "common.json#/identifierornull" },
 		"problem_id": { "$ref": "common.json#/identifierornull" },
 		"text": { "type": "string" },
-		"from_jury": { "type": "boolean" },
-		"to_all_teams": { "type": "boolean" },
 		"time": { "$ref": "common.json#/abstime" },
 		"contest_time": { "$ref": "common.json#/reltime" }
 	},

--- a/contest-api/json-schema/commentaries.json
+++ b/contest-api/json-schema/commentaries.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "CLICS Contest API: commentary",
+	"description": "JSON response of this API call",
+
+	"type": "array",
+	"uniqueItems": true,
+	"$ref": "common.json#/nonemptyarray",
+	"items": {
+		"$ref": "commentary.json#"
+	}
+}

--- a/contest-api/json-schema/commentary.json
+++ b/contest-api/json-schema/commentary.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "CLICS Contest API - commentary",
+	"description": "Definition of a single commentary object",
+
+	"type": "object",
+	"properties": {
+		"id": { "$ref": "common.json#/identifier" },
+		"time": { "$ref": "common.json#/abstime" },
+		"contest_time": { "$ref": "common.json#/reltime" },
+		"message": { "type": "string" },
+		"team_ids": {
+			"type": "array",
+			"uniqueItems": true,
+			"items": { "$ref": "common.json#/identifier" }
+		},
+		"problem_ids": {
+			"type": "array",
+			"uniqueItems": true,
+			"items": { "$ref": "common.json#/identifier" }
+		}
+	},
+	"required": ["id", "time", "contest_time", "message", "team_ids", "problem_ids"],
+	"$ref": "common.json#/strictproperties"
+}

--- a/contest-api/json-schema/commentary.json
+++ b/contest-api/json-schema/commentary.json
@@ -9,16 +9,8 @@
 		"time": { "$ref": "common.json#/abstime" },
 		"contest_time": { "$ref": "common.json#/reltime" },
 		"message": { "type": "string" },
-		"team_ids": {
-			"type": "array",
-			"uniqueItems": true,
-			"items": { "$ref": "common.json#/identifier" }
-		},
-		"problem_ids": {
-			"type": "array",
-			"uniqueItems": true,
-			"items": { "$ref": "common.json#/identifier" }
-		}
+		"team_ids": { "$ref": "common.json#/identifiersornull" },
+		"problem_ids": { "$ref": "common.json#/identifiersornull" }
 	},
 	"required": ["id", "time", "contest_time", "message", "team_ids", "problem_ids"],
 	"$ref": "common.json#/strictproperties"

--- a/contest-api/json-schema/common.json
+++ b/contest-api/json-schema/common.json
@@ -62,7 +62,7 @@
 
 	"identifier": {
 		"type": "string",
-		"pattern": "^[A-Za-z0-9_][A-Za-z0-9_-]{0,35}"
+		"pattern": "^[A-Za-z0-9_]([A-Za-z0-9_\\.-]{0,34}[A-Za-z0-9_-]|)"
 	},
 
 	"identifierornull": {

--- a/contest-api/json-schema/common.json
+++ b/contest-api/json-schema/common.json
@@ -73,6 +73,19 @@
 		]
 	},
 
+	"identifiers": {
+		"type": "array",
+		"uniqueItems": true,
+		"items": { "$ref": "#/identifier" }
+	},
+
+	"identifiersornull": {
+		"oneOf": [
+			{ "$ref": "#/identifiers" },
+			{ "type": "null" }
+		]
+	},
+
 	"judgementtypeid": {
 		"enum": [
 			"AC", "RE", "WA", "TLE", "RTE", "CE", "APE", "OLE", "PE", "EO", "IO", "NO",
@@ -114,12 +127,50 @@
 		"$ref": "#/strictproperties"
 	},
 
+	"imageref": {
+		"allOf": [
+			{ "$ref": "#/fileref" },
+			{
+				"properties": {
+					"mime": { "enum": ["image/png", "image/jpeg", "image/svg+xml"] }
+				},
+				"required": ["width", "height"]
+			}
+		]
+	},
+
 	"filerefs": {
 		"type": "array",
 		"uniqueItems": true,
 		"items": {
 			"$ref": "#/fileref"
 		}
+	},
+
+	"filerefsornull": {
+		"oneOf": [
+			{
+				"type": "array",
+				"uniqueItems": true,
+				"items": {
+					"$ref": "#/fileref"
+				}
+			},
+			{ "type": "null" }
+		]
+	},
+
+	"imagerefsornull": {
+		"oneOf": [
+			{
+				"type": "array",
+				"uniqueItems": true,
+				"items": {
+					"$ref": "#/imageref"
+				}
+			},
+			{ "type": "null" }
+		]
 	},
 
 	"command": {
@@ -132,6 +183,13 @@
 		},
 		"required": ["command"],
 		"$ref": "#/strictproperties"
+	},
+
+	"commandornull": {
+		"oneOf": [
+			{ "$ref": "#/command" },
+			{ "type": "null" }
+		]
 	},
 
 	"$comment": "Inside here add '\"minItems\": 1' to require all collection endpoints to contain at least one element.",

--- a/contest-api/json-schema/common.json
+++ b/contest-api/json-schema/common.json
@@ -124,7 +124,18 @@
 		"items": {
 			"$ref": "#/fileref"
 		}
+	},
 
+	"command": {
+		"type": "object",
+		"properties": {
+			"command": { "type": "string" },
+			"args": { "type": "string" },
+			"version": { "type": "string" },
+			"version-command": { "type": "string" }
+		},
+		"required": ["command"],
+		"$ref": "#/strictproperties"
 	},
 
 	"$comment": "Inside here add '\"minItems\": 1' to require all collection endpoints to contain at least one element.",

--- a/contest-api/json-schema/common.json
+++ b/contest-api/json-schema/common.json
@@ -102,11 +102,6 @@
 		"minimum": 0
 	},
 
-	"decimal": {
-		"type": "number",
-		"multipleOf": 0.001
-	},
-
 	"fileref": {
 		"type": "object",
 		"properties": {

--- a/contest-api/json-schema/common.json
+++ b/contest-api/json-schema/common.json
@@ -19,6 +19,7 @@
 			"runs",
 			"clarifications",
 			"awards",
+			"commentary",
 			"scoreboard",
 			"event-feed"
 		]

--- a/contest-api/json-schema/contest.json
+++ b/contest-api/json-schema/contest.json
@@ -16,8 +16,8 @@
 			"type": "integer",
 			"minimum": 0
 		},
-		"banner": { "$ref": "common.json#/filerefs" },
-		"logo": { "$ref": "common.json#/filerefs" }
+		"banner": { "$ref": "common.json#/imagerefsornull" },
+		"logo": { "$ref": "common.json#/imagerefsornull" }
 	},
 	"required": ["id", "name", "duration"],
 	"$ref": "common.json#/strictproperties"

--- a/contest-api/json-schema/event-feed.json
+++ b/contest-api/json-schema/event-feed.json
@@ -28,7 +28,8 @@
 						{ "$ref": "judgement.json#" },
 						{ "$ref": "run.json#" },
 						{ "$ref": "clarification.json#" },
-						{ "$ref": "award.json#" }
+						{ "$ref": "award.json#" },
+						{ "$ref": "commentary.json#" }
 					]
 				}
 			}

--- a/contest-api/json-schema/group.json
+++ b/contest-api/json-schema/group.json
@@ -8,7 +8,7 @@
 		"id": { "$ref": "common.json#/identifier" },
 		"icpc_id": { "type": [ "string", "null" ] },
 		"name": { "type": "string" },
-		"type": { "type": "string" }
+		"type": { "type": [ "string", "null" ] }
 	},
 	"required": ["id", "name"],
 	"$ref": "common.json#/strictproperties"

--- a/contest-api/json-schema/group.json
+++ b/contest-api/json-schema/group.json
@@ -8,8 +8,7 @@
 		"id": { "$ref": "common.json#/identifier" },
 		"icpc_id": { "type": [ "string", "null" ] },
 		"name": { "type": "string" },
-		"type": { "type": "string" },
-		"hidden": { "type": "boolean" }
+		"type": { "type": "string" }
 	},
 	"required": ["id", "name"],
 	"$ref": "common.json#/strictproperties"

--- a/contest-api/json-schema/judgement.json
+++ b/contest-api/json-schema/judgement.json
@@ -15,7 +15,8 @@
 		"max_run_time": {
 			"oneOf": [
 				{
-					"$ref": "common.json#/decimal",
+					"type": "number",
+					"multipleOf": 0.001,
 					"minimum": 0
 				},
 				{ "type": "null" }

--- a/contest-api/json-schema/language.json
+++ b/contest-api/json-schema/language.json
@@ -6,8 +6,32 @@
 	"type": "object",
 	"properties": {
 		"id": { "$ref": "common.json#/identifier" },
-		"name": { "type": "string" }
+		"name": { "type": "string" },
+		"entry_point_required": { "type": "boolean" },
+		"entry_point_name": { "type": [ "string", "null" ] },
+		"extensions": {
+			"type": "array",
+			"uniqueItems": true,
+			"items": { "type": "string" }
+		},
+		"compiler": { "$ref": "common.json#/command" },
+		"runner": { "$ref": "common.json#/command" }
 	},
-	"required": ["id", "name"],
+	"oneOf": [
+		{
+			"properties": { "entry_point_required": { "enum": [false] } },
+			"not": { "required": ["entry_point_name"] }
+		},
+		{
+			"properties": { "entry_point_required": { "enum": [false] } },
+			"properties": { "entry_point_name": { "enum": [null] } }
+		},
+		{
+			"properties": { "entry_point_required": { "enum": [true] } },
+			"properties": { "entry_point_name": { "type": "string" } },
+			"required": ["entry_point_name"]
+		}
+	],
+	"required": ["id", "name", "entry_point_required", "extensions"],
 	"$ref": "common.json#/strictproperties"
 }

--- a/contest-api/json-schema/language.json
+++ b/contest-api/json-schema/language.json
@@ -14,8 +14,8 @@
 			"uniqueItems": true,
 			"items": { "type": "string" }
 		},
-		"compiler": { "$ref": "common.json#/command" },
-		"runner": { "$ref": "common.json#/command" }
+		"compiler": { "$ref": "common.json#/commandornull" },
+		"runner": { "$ref": "common.json#/commandornull" }
 	},
 	"oneOf": [
 		{

--- a/contest-api/json-schema/organization.json
+++ b/contest-api/json-schema/organization.json
@@ -18,6 +18,7 @@
 				{ "type": "null" }
 			]
 		},
+		"country_flag": { "$ref": "common.json#/imagerefsornull" },
 		"url": { "type": [ "string", "null" ] },
 		"twitter_hashtag": { "type": [ "string", "null" ] },
 		"location": {
@@ -42,7 +43,7 @@
 				{ "type": "null" }
 			]
 		},
-		"logo": { "$ref": "common.json#/filerefs" }
+		"logo": { "$ref": "common.json#/imagerefsornull" }
 	},
 	"required": ["id", "name"],
 	"$ref": "common.json#/strictproperties"

--- a/contest-api/json-schema/problem.json
+++ b/contest-api/json-schema/problem.json
@@ -6,6 +6,15 @@
 	"type": "object",
 	"properties": {
 		"id": { "$ref": "common.json#/identifier" },
+		"uuid": {
+			"oneOf": [
+				{
+					"type": "string",
+					"pattern": "^[A-Fa-f0-9]{8}-([A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}$"
+				},
+				{ "type": "null" }
+			]
+		},
 		"label": { "$ref": "common.json#/label" },
 		"name": { "type": "string" },
 		"ordinal": { "$ref": "common.json#/ordinal" },

--- a/contest-api/json-schema/problem.json
+++ b/contest-api/json-schema/problem.json
@@ -15,7 +15,8 @@
 		},
 		"color": { "type": "string" },
 		"time_limit": {
-			"$ref": "common.json#/decimal",
+			"type": "number",
+			"multipleOf": 0.001,
 			"minimum": 0
 		},
 		"test_data_count": {

--- a/contest-api/json-schema/run.json
+++ b/contest-api/json-schema/run.json
@@ -12,7 +12,8 @@
 		"time": { "$ref": "common.json#/abstime" },
 		"contest_time": { "$ref": "common.json#/reltime" },
 		"run_time": {
-			"$ref": "common.json#/decimal",
+			"type": "number",
+			"multipleOf": 0.001,
 			"minimum": 0
 		}
 	},

--- a/contest-api/json-schema/submission.json
+++ b/contest-api/json-schema/submission.json
@@ -13,7 +13,7 @@
 		"contest_time": { "$ref": "common.json#/reltime" },
 		"entry_point": { "type": [ "string", "null" ] },
 		"files": { "$ref": "common.json#/filerefs" },
-		"reaction": { "$ref": "common.json#/filerefs" }
+		"reaction": { "$ref": "common.json#/filerefsornull" }
 	},
 	"required": ["id", "language_id", "problem_id", "team_id", "time", "contest_time", "files"],
 	"$ref": "common.json#/strictproperties"

--- a/contest-api/json-schema/submission.json
+++ b/contest-api/json-schema/submission.json
@@ -16,5 +16,33 @@
 		"reaction": { "$ref": "common.json#/filerefsornull" }
 	},
 	"required": ["id", "language_id", "problem_id", "team_id", "time", "contest_time", "files"],
+	"oneOf": [
+		{
+			"properties": {
+				"language_id": { "enum": ["java"] }
+			},
+			"required": ["entry_point"]
+		},
+		{
+			"properties": {
+				"language_id": { "enum": ["c", "cpp"] }
+			},
+			"oneOf": [
+				{
+					"not": { "required": ["entry_point"] }
+				},
+				{
+					"properties": { "entry_point": { "type": "null" } }
+				}
+			]
+		},
+		{
+			"not": {
+				"properties": {
+					"language_id": { "enum": ["java", "c", "cpp"] }
+				}
+			}
+		}
+	],
 	"$ref": "common.json#/strictproperties"
 }

--- a/contest-api/json-schema/team-member.json
+++ b/contest-api/json-schema/team-member.json
@@ -17,7 +17,7 @@
 			]
 		},
 		"role": { "enum": [ "contestant", "coach" ] },
-		"photo": { "$ref": "common.json#/filerefs" }
+		"photo": { "$ref": "common.json#/imagerefsornull" }
 	},
 	"required": ["id", "team_id", "first_name", "last_name"],
 	"$ref": "common.json#/strictproperties"

--- a/contest-api/json-schema/team-member.json
+++ b/contest-api/json-schema/team-member.json
@@ -19,6 +19,6 @@
 		"role": { "enum": [ "contestant", "coach" ] },
 		"photo": { "$ref": "common.json#/imagerefsornull" }
 	},
-	"required": ["id", "team_id", "first_name", "last_name"],
+	"required": ["id", "team_id", "first_name", "last_name", "role"],
 	"$ref": "common.json#/strictproperties"
 }

--- a/contest-api/json-schema/team.json
+++ b/contest-api/json-schema/team.json
@@ -28,8 +28,11 @@
 		"photo": { "$ref": "common.json#/filerefs" },
 		"video": { "$ref": "common.json#/filerefs" },
 		"backup": { "$ref": "common.json#/filerefs" },
+		"key_log": { "$ref": "common.json#/filerefs" },
+		"tool_data": { "$ref": "common.json#/filerefs" },
 		"desktop": { "$ref": "common.json#/filerefs" },
-		"webcam": { "$ref": "common.json#/filerefs" }
+		"webcam": { "$ref": "common.json#/filerefs" },
+		"audio": { "$ref": "common.json#/filerefs" }
 	},
 	"required": ["id", "name"],
 	"$ref": "common.json#/strictproperties"

--- a/contest-api/json-schema/team.json
+++ b/contest-api/json-schema/team.json
@@ -15,6 +15,7 @@
 			"uniqueItems": true,
 			"items": { "$ref": "common.json#/identifierornull" }
 		},
+		"hidden": { "type": [ "boolean", "null" ] },
 		"location": {
 			"type": "object",
 			"properties": {

--- a/contest-api/json-schema/team.json
+++ b/contest-api/json-schema/team.json
@@ -10,11 +10,7 @@
 		"name": { "type": "string" },
 		"display_name": { "type": [ "string", "null" ] },
 		"organization_id": { "$ref": "common.json#/identifierornull" },
-		"group_ids": {
-			"type": "array",
-			"uniqueItems": true,
-			"items": { "$ref": "common.json#/identifierornull" }
-		},
+		"group_ids": { "$ref": "common.json#/identifiersornull" },
 		"hidden": { "type": [ "boolean", "null" ] },
 		"location": {
 			"type": "object",
@@ -26,14 +22,14 @@
 			"required": ["x", "y", "rotation"],
 			"$ref": "common.json#/strictproperties"
 		},
-		"photo": { "$ref": "common.json#/filerefs" },
-		"video": { "$ref": "common.json#/filerefs" },
-		"backup": { "$ref": "common.json#/filerefs" },
-		"key_log": { "$ref": "common.json#/filerefs" },
-		"tool_data": { "$ref": "common.json#/filerefs" },
-		"desktop": { "$ref": "common.json#/filerefs" },
-		"webcam": { "$ref": "common.json#/filerefs" },
-		"audio": { "$ref": "common.json#/filerefs" }
+		"photo": { "$ref": "common.json#/imagerefsornull" },
+		"video": { "$ref": "common.json#/filerefsornull" },
+		"backup": { "$ref": "common.json#/filerefsornull" },
+		"key_log": { "$ref": "common.json#/filerefsornull" },
+		"tool_data": { "$ref": "common.json#/filerefsornull" },
+		"desktop": { "$ref": "common.json#/filerefsornull" },
+		"webcam": { "$ref": "common.json#/filerefsornull" },
+		"audio": { "$ref": "common.json#/filerefsornull" }
 	},
 	"required": ["id", "name"],
 	"$ref": "common.json#/strictproperties"

--- a/contest-api/json-schema/team.json
+++ b/contest-api/json-schema/team.json
@@ -17,7 +17,11 @@
 			"properties": {
 				"x": { "type": "number" },
 				"y": { "type": "number" },
-				"rotation": { "type": "number" }
+				"rotation": {
+					"type": "number",
+					"minimum": 0,
+					"maximum": 360
+				}
 			},
 			"required": ["x", "y", "rotation"],
 			"$ref": "common.json#/strictproperties"


### PR DESCRIPTION
These are mostly updates to the JSON schema to make it up to date with the current specification at https://ccs-specs.icpc.io/contest_api. The only things that are (or should be) missing:

- Contest `scoreboard_type` and related changes to other endpoints.
- Any draft changes to the event feed and webhooks.
