### PR TITLE
Remove link to sources directory.

### DIFF
--- a/website/download.shtml
+++ b/website/download.shtml
@@ -75,9 +75,6 @@ the documentation here</a> for more details on how use these.
 
 <h3>Other downloads</h3>
 
-<p>Also available are the
-<a href="sources/">sources of included {b,d}ash shell</a> binaries.</p>
-
 <p>The <a href="/snapshot/">snapshot directory</a> contains nightly builds,
 including changelog and documentation, <strong>use at your own risk</strong>.</p>
 


### PR DESCRIPTION
DOMjudge releases don't contain a statically compiled
bash/dash shell anymore since 173b380a62b496ec9a47a847
in the main domjudge repo.

The sources directory has been moved under the releases directory
on domjudge.org, since we still need to provide these for older
releases. Just refer to this in the README in releases instead of
on the download page.