### PR TITLE
Add judgehost .target systemd file.

### DIFF
--- a/icpc-wf/ansible/roles/judgedaemon/handlers/main.yml
+++ b/icpc-wf/ansible/roles/judgedaemon/handlers/main.yml
@@ -12,10 +12,9 @@
 
 - name: enable and restart judgedaemon
   service:
-    name="domjudge-judgedaemon@{{item}}"
+    name="domjudge-judgehost.target"
     enabled=yes
     state=restarted
-  loop: "{{CPUCORE}}"
 
 - name: update grub
   shell: update-grub

--- a/icpc-wf/ansible/roles/judgedaemon/tasks/main.yml
+++ b/icpc-wf/ansible/roles/judgedaemon/tasks/main.yml
@@ -74,6 +74,13 @@
   notify:
     - restart systemctl
     - enable and restart create-cgroups
+
+- name: template judgedaemon template systemd unit file
+  template:
+    src: domjudge-judgehost.target.j2
+    dest: /etc/systemd/system/
+  notify:
+    - restart systemctl
     - enable and restart judgedaemon
 
 - name: disable systemd timers

--- a/icpc-wf/ansible/roles/judgedaemon/templates/domjudge-judgehost.target.j2
+++ b/icpc-wf/ansible/roles/judgedaemon/templates/domjudge-judgehost.target.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=DOMjudge judgehost running one or more judgedaemons
+Requires={% for core in CPUCORE %}domjudge-judgedaemon@{{ core }}.service {% endfor %}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Our .service can't be enabled (anymore?) since it does not have a `[Install]` section, but we have a .target for that in the main repo. This templates out this .target file.

cc @edomora97 this is what we talked about yesterday.