### PR TITLE
Only make replication an explicit choice

### DIFF
--- a/provision-contest/ansible/domserver.yml
+++ b/provision-contest/ansible/domserver.yml
@@ -34,6 +34,7 @@
       tags: domserver
     - role: mysql_replication
       tags: mysql_replication
+      when: REPLICATION_PASSWORD is defined
     - role: keepalived
       tags: keepalived
       when: KEEPALIVED_PRIORITY is defined

--- a/provision-contest/ansible/group_vars/all/secret.yml.example
+++ b/provision-contest/ansible/group_vars/all/secret.yml.example
@@ -1,6 +1,6 @@
 # Password for the MySQL replication user.
 # Set this to enable master-master replication between two domservers.
-REPLICATION_PASSWORD: some-replication-password
+#REPLICATION_PASSWORD: some-replication-password
 
 # Database user password.
 DB_PASSWORD: some-database-password


### PR DESCRIPTION
In most cases we dont do replication and this book will let SQL bind to 0.0.0.0 which is less secure and only relevant when making use of the replication.