### PR TITLE
Link to example compose file

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -3,7 +3,7 @@ SHELL = /bin/bash
 WWWDIR = /srv/http/domjudge
 
 install:
-	cp *.shtml *.css *.ico *.svg *.pdf $(WWWDIR)/
+	cp *.shtml *.css *.ico *.svg *.pdf *.yml $(WWWDIR)/
 
 # This takes the docs from the latest (by string sorting) release and copies
 # these to the directory serving files under www.domjudge.org/docs/.

--- a/website/docker-compose.yml
+++ b/website/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  mariadb:
+    image: docker.io/mariadb
+    hostname: mariadb
+    environment:
+      - MYSQL_ROOT_PASSWORD=domjudge
+      - MYSQL_USER=domjudge
+      - MYSQL_PASSWORD=djpw
+      - MYSQL_DATABASE=domjudge
+    ports:
+      - 13306:3306
+    command: --max-connections=1000 --max-allowed-packet=512M
+    volumes:
+      - /var/lib/mysql
+  domjudge:
+    image: docker.io/domjudge/domserver
+    hostname: domserver
+    environment:
+      - MYSQL_ROOT_PASSWORD=domjudge
+      - MYSQL_USER=domjudge
+      - MYSQL_PASSWORD=djpw
+      - MYSQL_DATABASE=domjudge
+      - MYSQL_HOST=mariadb
+    ports:
+      - 8080:80

--- a/website/download.shtml
+++ b/website/download.shtml
@@ -41,8 +41,7 @@ mailing list</a>.</p>
 <h3>DOMjudge docker images</h3>
 
 <p>Official Docker images for both the domserver and judgehost are also available.
-See the <a href="https://hub.docker.com/r/domjudge/domserver/">Docker Hub
-repository for the DOMserver</a> to get started.
+See the <a href="https://hub.docker.com/r/domjudge/domserver/">Docker Hub repository for the DOMserver</a> to get started or use the example <a href="docker-compose.yml">docker-compose</a> setup.
 </p>
 
 <h3>Debian Packages</h3>


### PR DESCRIPTION
The current documentation at Docker Hub uses the harder to use vanilla
docker. Current standard for deploying multiple containers is
docker-compose which is now added.

I've left judgehosts out of the compose as for these one would use other
machines where just running 1 container might actually be easier.