### PR TITLE
Setup dependabot on released version

### DIFF
--- a/new_release_howto.md
+++ b/new_release_howto.md
@@ -42,3 +42,4 @@ on the account `domjudge@vm-domjudge`):
  1. Put debian packages in `/srv/http/domjudge/debian/mini-dinstall/incoming`
     and run as domjudge@domjudge: `mini-dinstall -b`
  1. Send an email to `domjudge-announce@domjudge.org`.
+ 1. Add the released branch to the dependabot.yml (https://github.com/DOMjudge/domjudge/blob/main/.github/dependabot.yml)


### PR DESCRIPTION
When we release a version we want to patch any security issues with dependencies. Dependabot will not monitor these branches without explicit telling it to do so.