### PR TITLE
Mention re-released DOMjudge version

### DIFF
--- a/website/header.shtml
+++ b/website/header.shtml
@@ -1,5 +1,5 @@
-<!--#set    var="dj_current_branch_version"  value="8.1.1"
---><!--#set var="dj_current_branch_date"     value="11 July 2022"
+<!--#set    var="dj_current_branch_version"  value="8.1.2"
+--><!--#set var="dj_current_branch_date"     value="23 July 2022"
 --><!--#set var="dj_previous_branch_version" value="8.0.1"
 --><!--#set var="dj_previous_branch_date"    value="11 July 2022"
 --><!--#set var="dj_rc_branch_version"       value="6.0.0RC1"


### PR DESCRIPTION
DOMjudge v8.1.1 was wrongly tagged so missed the Changelog, the v8.1.2 only has the fix for this so the latest version is a proper tarball.