### PR TITLE
Update check-api script to support new event feed format.

### DIFF
--- a/contest-api/json-schema/common.json
+++ b/contest-api/json-schema/common.json
@@ -27,6 +27,30 @@
 		]
 	},
 
+	"endpointssingularcontest": {
+		"enum": [
+			"contest",
+			"judgement-types",
+			"languages",
+			"problems",
+			"groups",
+			"organizations",
+			"persons",
+			"team-members",
+			"accounts",
+			"teams",
+			"state",
+			"submissions",
+			"judgements",
+			"runs",
+			"clarifications",
+			"awards",
+			"commentary",
+			"scoreboard",
+			"event-feed"
+		]
+	},
+
 	"abstime": {
 		"type": "string",
 		"pattern": "^[12][0-9]{3}-[01][0-9]-[0-3][0-9]T[0-2][0-9]:[0-6][0-9]:[0-6][0-9](\\.[0-9]{3})?([+-][0-1][0-9](:[0-5][0-9])?|Z)$"

--- a/contest-api/json-schema/event-feed-array.json
+++ b/contest-api/json-schema/event-feed-array.json
@@ -4,9 +4,12 @@
 	"description": "JSON array of responses of this NDJSON API call",
 
 	"type": "array",
-	"uniqueItems": true,
 	"$ref": "common.json#/nonemptyarray",
 	"items": {
-		"$ref": "event-feed.json#"
+		"$comment": "Use anyOf since the event type fields overlap between the current and legacy format.",
+		"anyOf": [
+			{ "$ref": "event-feed.json#" },
+			{ "$ref": "legacy-event-feed.json#" }
+		]
 	}
 }

--- a/contest-api/json-schema/legacy-event-feed.json
+++ b/contest-api/json-schema/legacy-event-feed.json
@@ -5,23 +5,13 @@
 
 	"type": "object",
 	"properties": {
-		"id": {
-			"oneOf": [
-				{ "$ref": "common.json#/identifier" },
-				{ "type": "null" }
-			]
-		},
-		"token": {
-			"oneOf": [
-				{ "type": "string" },
-				{ "type": "null" }
-			]
-		},
-		"type": { "$ref": "common.json#/endpointssingularcontest" }
+		"id": { "$ref": "common.json#/identifier" },
+		"type": { "$ref": "common.json#/endpoints" }
 	},
 	"oneOf": [
 		{
 			"properties": {
+				"op": { "enum": [ "create", "update" ] },
 				"data": {
 					"$comment": "Use anyOf since some types match others without strict attribute checking.",
 					"anyOf": [
@@ -48,12 +38,18 @@
 		},
 		{
 			"properties": {
+				"op": { "enum": [ "delete" ] },
 				"data": {
-					"type": "null"
+					"type": "object",
+					"properties": {
+						"id": { "$ref": "common.json#/identifier" }
+					},
+					"required": ["id"],
+					"$ref": "common.json#/strictproperties"
 				}
 			}
 		}
 	],
-	"required": ["id", "type", "data"],
+	"required": ["id", "type", "op", "data"],
 	"$ref": "common.json#/strictproperties"
 }


### PR DESCRIPTION
Some remarks / questions:
*  I'm not a fan of the `endpointssingularcontest` in `common.json` but I'm not sure how to fix that the new feed uses singular `contest`. This also 'bytes' us in the PHP script to check consistency.
* I needed to get rid of `uniqueItems` since the new feed format can have the exact same event twice.
* @eldering mentioned yesterday that he might want to have a branch per spec version, but then we should probably first move this out of this repo? Or we add a flag to denote the version but I'm not sure if that won't get super messy. For now I decided to support both versions, since then our CI will keep working when I open the PR for the new format in the main repo.