### PR TITLE
Precreate default SSL certificate for CDS machine

### DIFF
--- a/provision-contest/ansible/Makefile
+++ b/provision-contest/ansible/Makefile
@@ -14,6 +14,8 @@ SSL_DOMSERVER=roles/ssl/files/domserver
 SSL_DOMSERVER_FILES=$(addprefix $(SSL_DOMSERVER),.key .crt)
 SSL_LOCALHOST=roles/ssl/files/localhost
 SSL_LOCALHOST_FILES=$(addprefix $(SSL_LOCALHOST),.key .crt)
+SSL_CDS=roles/ssl/files/cds
+SSL_CDS_FILES=$(addprefix $(SSL_CDS),.key .crt)
 SSL_GRAFANA=roles/grafana/files/ssl
 SSL_GRAFANA_FILES=$(addprefix $(SSL_GRAFANA),.key .crt)
 
@@ -31,6 +33,7 @@ domserver judgehost admin grafana cds scoreboard mgmt: %: %.yml hosts group_vars
 admin: $(SSL_LOCALHOST_FILES)
 grafana: $(SSL_GRAFANA_FILES)
 domserver: $(SSL_DOMSERVER_FILES)
+cds: $(SSL_CDS_FILES)
 
 $(SSHKEY) $(SSHKEY).pub:
 	ssh-keygen -t rsa -f $(SSHKEY) -P ''
@@ -41,6 +44,9 @@ $(SSL_DOMSERVER_FILES):
 $(SSL_LOCALHOST_FILES):
 	openssl req -x509 -nodes -newkey rsa:4096 -subj "/O=DOMjudge/CN=localhost" \
 		-sha256 -days 365 -keyout $(SSL_LOCALHOST).key -out $(SSL_LOCALHOST).crt
+$(SSL_CDS_FILES):
+	openssl req -x509 -nodes -newkey rsa:4096 -subj "/O=DOMjudge/CN=cds" \
+		-sha256 -days 365 -keyout $(SSL_CDS).key -out $(SSL_CDS).crt
 $(SSL_GRAFANA_FILES):
 	openssl req -x509 -nodes -newkey rsa:4096 -subj "/O=DOMjudge/CN=grafana" \
 		-sha256 -days 365 -keyout $(SSL_GRAFANA).key -out $(SSL_GRAFANA).crt
@@ -52,6 +58,7 @@ distclean: clean
 	rm -f $(SSHKEY) $(SSHKEY).pub
 	rm -f $(SSL_DOMSERVER_FILES)
 	rm -f $(SSL_LOCALHOST_FILES)
+	rm -f $(SSL_CDS_FILES)
 	rm -f $(SSL_GRAFANA_FILES)
 
 .PHONY: default clean distclean domserver judgehost admin grafana cds scoreboard


### PR DESCRIPTION
When running the CDS behind a proxy we still want a default certificate, this will now create this for such setups. As with the other ones they can still be overwritten in case someone has a more valid certificate later.