### PR TITLE
Ansible synchronize needs rsync for both client/server

### DIFF
--- a/provision-contest/ansible/mgmt.yml
+++ b/provision-contest/ansible/mgmt.yml
@@ -7,6 +7,8 @@
     host_type: mgmt
   become: true
   roles:
+    - role: base_packages
+      tags: base_packages
     - role: prometheus_target_all
       tags: prometheus_target_all
       when: GRAFANA_MONITORING

--- a/provision-contest/ansible/roles/base_packages/tasks/main.yml
+++ b/provision-contest/ansible/roles/base_packages/tasks/main.yml
@@ -105,6 +105,7 @@
       - latexmk
       - acl
       - gdb
+      - rsync
 
 - name: Check if composer is installed
   stat:


### PR DESCRIPTION
I think for the extra packages on the mgmt machine all of these make sense/are useful for our "jumphost"