### PR TITLE
Revert "Do not check for accounts consistency for now since we don't …

### DIFF
--- a/contest-api/check-api.sh
+++ b/contest-api/check-api.sh
@@ -327,7 +327,6 @@ $ENDPOINT"
 	fi
 
 	if [ -n "$CHECK_CONSISTENCY" ]; then
-		ENDPOINTS_CHECK_CONSISTENT="${ENDPOINTS_CHECK_CONSISTENT/accounts/}"
 		# shellcheck disable=SC2086
 		eval ${EXTRAPROP:-STRICT=1} "$MYDIR"/check-api-consistency.php "$TMP/$CONTEST" $ENDPOINTS_CHECK_CONSISTENT
 		EXIT=$?


### PR DESCRIPTION
…expose it in the feed."

This reverts commit 80d4cd6610ffffa5dc95356c8a0dd169244fcab7.

This breaks the check in our CI, that would complain about
```
Error: 'accounts/1' not found in REST endpoint.
Error: 'accounts/2' not found in REST endpoint.
Error: 'accounts/3' not found in REST endpoint.
```
Example: https://gitlab.com/DOMjudge/domjudge/-/jobs/3091941378#L4390

Reverting this commit makes CI succeed again.