### PR TITLE
Add tags to all dependencies to satisfy Ansible.

### DIFF
--- a/provision-contest/ansible/roles/domjudge_build/meta/main.yml
+++ b/provision-contest/ansible/roles/domjudge_build/meta/main.yml
@@ -2,4 +2,6 @@
 ---
 dependencies:
   - role: domjudge_user
+    tags: domjudge_user
   - role: domjudge_checkout
+    tags: domjudge_checkout

--- a/provision-contest/ansible/roles/domjudge_checkout/meta/main.yml
+++ b/provision-contest/ansible/roles/domjudge_checkout/meta/main.yml
@@ -2,3 +2,4 @@
 ---
 dependencies:
   - role: domjudge_user
+    tags: domjudge_user

--- a/provision-contest/ansible/roles/domserver/meta/main.yml
+++ b/provision-contest/ansible/roles/domserver/meta/main.yml
@@ -2,4 +2,6 @@
 ---
 dependencies:
   - role: mysql_server
+    tags: mysql_server
   - role: domjudge_build
+    tags: domjudge_build

--- a/provision-contest/ansible/roles/judgedaemon/meta/main.yml
+++ b/provision-contest/ansible/roles/judgedaemon/meta/main.yml
@@ -2,3 +2,4 @@
 ---
 dependencies:
   - role: domjudge_build
+    tags: domjudge_build

--- a/provision-contest/ansible/roles/keepalived/meta/main.yml
+++ b/provision-contest/ansible/roles/keepalived/meta/main.yml
@@ -2,3 +2,4 @@
 ---
 dependencies:
   - role: domjudge_user
+    tags: domjudge_user

--- a/provision-contest/ansible/roles/mysql_replication/meta/main.yml
+++ b/provision-contest/ansible/roles/mysql_replication/meta/main.yml
@@ -2,3 +2,4 @@
 ---
 dependencies:
   - role: mysql_server
+    tags: mysql_server

--- a/provision-contest/ansible/roles/phpstorm/meta/main.yml
+++ b/provision-contest/ansible/roles/phpstorm/meta/main.yml
@@ -2,3 +2,4 @@
 ---
 dependencies:
   - role: domjudge_user
+    tags: domjudge_user

--- a/provision-contest/ansible/roles/ssh/meta/main.yml
+++ b/provision-contest/ansible/roles/ssh/meta/main.yml
@@ -2,3 +2,4 @@
 ---
 dependencies:
   - role: domjudge_user
+    tags: domjudge_user


### PR DESCRIPTION
See https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#running-role-dependencies-multiple-times-in-one-play for the reason:
[...] If two roles in a play both list a third role as a dependency, Ansible only runs that role dependency once, unless you pass different parameters, tags, when clause, or use allow_duplicates: true in the role you want to run multiple times. [...]