### PR TITLE
Add playbooks for emergency situations

### DIFF
--- a/provision-contest/ansible/Makefile
+++ b/provision-contest/ansible/Makefile
@@ -35,6 +35,15 @@ CODEONLY_ROLES=$(addprefix codeonly-,domserver judgehost admin)
 $(CODEONLY_ROLES): codeonly-%:
 	ansible-playbook -i hosts --tags pretask,domjudge_build $*.yml
 
+powerloss:
+	ansible-playbook -i hosts emergency.yml --tags powerloss
+
+lockdown:
+	ansible-playbook -i hosts emergency.yml --tags full_lockdown
+
+lockdown-force:
+	ansible-playbook -i hosts emergency.yml --tags full_lockdown,force_lockdown
+
 admin: $(SSL_LOCALHOST_FILES)
 grafana: $(SSL_GRAFANA_FILES)
 domserver: $(SSL_DOMSERVER_FILES)
@@ -66,4 +75,4 @@ distclean: clean
 	rm -f $(SSL_CDS_FILES)
 	rm -f $(SSL_GRAFANA_FILES)
 
-.PHONY: default clean distclean $(ROLES) $(CODEONLY_ROLES)
+.PHONY: default clean distclean $(ROLES) $(CODEONLY_ROLES) powerloss lockdown lockdown-force

--- a/provision-contest/ansible/emergency.yml
+++ b/provision-contest/ansible/emergency.yml
@@ -1,0 +1,60 @@
+---
+- hosts: domserver
+  tasks:
+    - name: Disable webserver to stop submissions
+      tags: powerloss
+      service:
+        name: nginx
+        state: stopped
+
+- hosts: all
+  tasks:
+    - name: Disable GDM autologin
+      tags: full_lockdown
+      lineinfile:
+        path: /etc/gdm3/custom.conf
+        regexp: 'AutomaticLoginEnable'
+        line: 'AutomaticLoginEnable=false'
+        create: true
+        mode: 0644
+      when: GRAPHICAL
+
+- hosts: judgehost
+  tasks:
+    - name: Disable all running judgedaemons
+      tags: full_lockdown
+      service:
+        name: "{{ item }}"
+        state: stopped
+      with_sequence: start=0 end={{ ansible_processor_vcpus }} format=domjudge-judgedaemon@%1x
+
+- hosts: domserver:!emergency
+  tasks:
+    - name: Disable our domserver instance
+      # We also disable the startup as we're now in most likely a bad state
+      # make sure that replication can only start when someone is looking at it
+      tags: full_lockdown
+      service:
+        name: "{{ item }}"
+        state: stopped
+        enabled: false
+      loop:
+        - nginx
+        - php7.4-fpm
+        - mysql
+
+- hosts: all:!admin
+  tasks:
+    - name: Shutdown all non-needed computers
+      tags: full_lockdown
+      community.general.shutdown:
+
+# Get current running machine
+- hosts: localhost
+
+- hosts: all
+  tasks:
+    - name: Shutdown all machines except for us
+      tags: force_lockdown
+      community.general.shutdown:
+      when: hostvars.localhost.ansible_hostname != ansible_hostname

--- a/provision-contest/ansible/hosts.example
+++ b/provision-contest/ansible/hosts.example
@@ -9,6 +9,12 @@ ansible_python_interpreter=/usr/bin/python3
 domjudge-primary     ansible_host=10.3.3.216 KEEPALIVED_PRIORITY=100 EFI_ORDER='0\,1\,3\,4'
 domjudge-backup      ansible_host=10.3.3.217 KEEPALIVED_PRIORITY=99 EFI_ORDER='0\,1\,3\,4'
 
+[domserver:children]
+emergency
+
+[emergency]
+domjudge-laptop      ansible_host=10.3.3.218
+
 [judgehost]
 domjudge-judgehost1  ansible_host=10.2.2.192
 domjudge-judgehost2  ansible_host=10.2.2.193


### PR DESCRIPTION
I think in these situations it would be nice if we can already leave and this can just run in the background.

If we would make sure we know which station runs this lockdown we could make it better by doing the shutdown in the make command so all hosts except for the last admin machine are killed with ansible and then the last one stops.