### PR TITLE
Emergency unpause fixes

### DIFF
--- a/provision-contest/ansible/roles/domjudge_build/handlers/main.yml
+++ b/provision-contest/ansible/roles/domjudge_build/handlers/main.yml
@@ -2,6 +2,11 @@
 - name: Fix permissions on domjudge inplace-install
   command: make -C {{ DJ_DIR }} inplace-postinstall-permissions
 
+- name: Fix composer autoload
+  command:
+    cmd: composer dump-autoload -o
+    chdir: "{{ DJ_DIR }}"
+
 - name: Restart rsyslog
   service:
     name: rsyslog

--- a/provision-contest/ansible/roles/domjudge_build/tasks/main.yml
+++ b/provision-contest/ansible/roles/domjudge_build/tasks/main.yml
@@ -29,7 +29,9 @@
   command: make inplace-install
   args:
     chdir: "{{ DJ_DIR }}"
-  notify: Fix permissions on domjudge inplace-install
+  notify:
+    - Fix permissions on domjudge inplace-install
+    - Fix composer autoload
   when: (git_working_copy is defined and git_working_copy.changed) or dj_configured.changed or not judgedaemon_binary.stat.exists
 
 - name: Copy domjudge-sudoers file

--- a/provision-contest/ansible/roles/domserver/tasks/main.yml
+++ b/provision-contest/ansible/roles/domserver/tasks/main.yml
@@ -108,3 +108,12 @@
     - { key: 'php_admin_value[post_max_size]', regexp: '^php_admin_value\[post_max_size\]', value: '{{ PHP_POST_MAX_SIZE }}' }
     - { key: 'php_admin_value[max_file_uploads]', regexp: '^php_admin_value\[max_file_uploads\]', value: '{{ PHP_MAX_FILE_UPLOADS }}' }
   notify: Restart PHP FPM
+
+- name: Start domserver webservices
+  systemd:
+    name: "{{ item }}"
+    enabled: true
+    state: started
+  loop:
+    - nginx
+    - php{{ php_version.stdout }}-fpm

--- a/provision-contest/ansible/roles/mysql_server/tasks/main.yml
+++ b/provision-contest/ansible/roles/mysql_server/tasks/main.yml
@@ -46,6 +46,11 @@
 - name: Make sure mysql is restarted
   meta: flush_handlers
 
+- name: Make sure mysql runs
+  service:
+    name: mysql
+    state: started
+
 - name: Create directory to store scripts & database dumps
   file:
     path: /home/domjudge/{{ item }}


### PR DESCRIPTION
After testing with the emergency book these fixes where needed. We don't need them in a normal setup (but this should not hurt) as normally the installation of the package also enables these services.