### PR TITLE
Dont run apparmor on judgehosts

### DIFF
--- a/provision-contest/ansible/roles/judgedaemon/tasks/main.yml
+++ b/provision-contest/ansible/roles/judgedaemon/tasks/main.yml
@@ -49,7 +49,7 @@
 
 - name: Pre-generate the kernel flags for ansible usage
   set_fact:
-    procline: "systemd.unified_cgroup_hierarchy=0 cgroup_enable=memory swapaccount=1 isolcpus={{ cpucore | join(',') }}"
+    procline: "apparmor=0 systemd.unified_cgroup_hierarchy=0 cgroup_enable=memory swapaccount=1 isolcpus={{ cpucore | join(',') }}"
 
 - name: Add cgroup kernel parameters
   lineinfile:


### PR DESCRIPTION
We already guard with runguard and the rest of the machine is considered to be trusted.

Before we do this I want to do some testing, but I think having the discussion is also good. I'm not sure if we can actually make a profile for apparmor to maybe replace runguard (and if that would be less heavy/better optimized?)