### PR TITLE
Default only deploy maintainers

### DIFF
--- a/provision-contest/ansible/roles/ssh/defaults/main.yml
+++ b/provision-contest/ansible/roles/ssh/defaults/main.yml
@@ -1,11 +1,8 @@
-github_ssh_user:
-  - meisterT
-  - nickygerritsen
-  - thijskh
-  - tuupke
-  - ubergeek42
-  - vmcj
+#github_ssh_user:
+#  - github_user
+#
+#ssh_public_keys:
+#  - "ssh-ed25519 AAAABCDEFGHIJKLMNOPQRSTUVWXYZBCDEFGHIJKLMNOPQRSTUVWXYZBCDEFGHIJKLMNO user@machine"
 
-ssh_public_keys:
-  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICd/P3Mu0X0hE9yc+k4cU/eT67S4F4E8Lmxk4yYDM8qL jaap@diamond"
-  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrtJzsraIV4SFFkeu5HtxwRZKBOwn2dL/g1CJhaCwJs jaap@tiger"
+github_ssh_user: []
+ssh_public_keys: []

--- a/provision-contest/ansible/roles/ssh/defaults/main.yml
+++ b/provision-contest/ansible/roles/ssh/defaults/main.yml
@@ -5,9 +5,6 @@ github_ssh_user:
   - tuupke
   - ubergeek42
   - vmcj
-  - deboer-tim
-  - edomora97
-  - SuprDewd
 
 ssh_public_keys:
   - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICd/P3Mu0X0hE9yc+k4cU/eT67S4F4E8Lmxk4yYDM8qL jaap@diamond"

--- a/provision-contest/ansible/roles/ssh/vars/maintainers.yml.example
+++ b/provision-contest/ansible/roles/ssh/vars/maintainers.yml.example
@@ -1,0 +1,11 @@
+github_ssh_user:
+  - meisterT
+  - nickygerritsen
+  - thijskh
+  - tuupke
+  - ubergeek42
+  - vmcj
+
+ssh_public_keys:
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICd/P3Mu0X0hE9yc+k4cU/eT67S4F4E8Lmxk4yYDM8qL jaap@diamond"
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrtJzsraIV4SFFkeu5HtxwRZKBOwn2dL/g1CJhaCwJs jaap@tiger"


### PR DESCRIPTION
I trust all of the removed ones, but this was only added for the WF pretests and should not have made it into the main code.