### PR TITLE
Cds fixes

### DIFF
--- a/provision-contest/ansible/group_vars/all/all.yml.example
+++ b/provision-contest/ansible/group_vars/all/all.yml.example
@@ -89,3 +89,7 @@ STATIC_SCOREBOARD_HOSTNAME: scoreboard
 STATIC_SCOREBOARD_SSL_CERT: /etc/ssl/certs/scoreboard.crt
 STATIC_SCOREBOARD_SSL_KEY: /etc/ssl/private/scoreboard.key
 
+# Block access to the CDS for IPs other than these
+#CDS_IP_FILTER:
+#  - 127.0.0.1-127.0.0.1
+#  - 192.168.0.0-192.168.255.255

--- a/provision-contest/ansible/roles/cds/templates/cds.conf.j2
+++ b/provision-contest/ansible/roles/cds/templates/cds.conf.j2
@@ -1,4 +1,15 @@
 # nginx configuration for the CDS
+
+{% if CDS_IP_FILTER is defined %}
+geo $network {
+    ranges;
+    default            BLOCK;
+{% for range in CDS_IP_FILTER %}
+    {{ range }}        ALLOW;
+{% endfor %}
+}
+{% endif %}
+
 server {
 	listen {{ CDS_PORT }};
 	listen [::]:{{ CDS_PORT }};
@@ -26,7 +37,13 @@ server {
 		proxy_set_header X-Forwarded-Proto https;
 		proxy_set_header Host $host;
 
-		proxy_pass https://localhost:8443;
+		{% if CDS_IP_FILTER is defined %}
+        if ( $network = ALLOW) {
+            proxy_pass https://localhost:8443;
+        }
+        {% else %}
+            proxy_pass https://localhost:8443;
+        {% endif %}
 
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
I think this can also be relevant for other tools we run on the servers,

The CDS seems to default disclose the number of problems, which is annoying if the contest is what we call "non" public. The problemset used here is still under embargo but the server does run in the cloud.