### PR TITLE
Mention the automatic job to rebuild the docker containers

### DIFF
--- a/new_release_howto.md
+++ b/new_release_howto.md
@@ -42,6 +42,7 @@ on the account `domjudge@vm-domjudge`):
     `Run pipeline`, make sure to click the *play* button next to `release-DOMjudge`
     to actually build and push the Docker images. You can view the progress by
     clicking on the job.
+ 1. Update https://gitlab.com/DOMjudge/domjudge-packaging/-/pipeline\_schedules to the latest version.
  1. Build Debian packages (or make someone do this).
  1. Put debian packages in `/srv/http/domjudge/debian/mini-dinstall/incoming`
     and run as domjudge@domjudge: `mini-dinstall -b`


### PR DESCRIPTION
In theory we can grab this in the job by checking what is the highest semantic version.

The goal of this is to get less messages from snyk/scout that we have packages with a problem in them.