### PR TITLE
Sort CPUs/cores in disable turboboost script numerically.

### DIFF
--- a/provision-contest/disable-turboboost_ht
+++ b/provision-contest/disable-turboboost_ht
@@ -5,7 +5,7 @@ shopt -s extglob
 
 declare -A core_ids
 
-for cpu in /sys/devices/system/cpu/cpu* ; do
+for cpu in $(ls -1d /sys/devices/system/cpu/cpu* | sort --version-sort) ; do
 	[[ $(basename $cpu) =~ ^cpu[0-9]+$ ]] || continue
 
 	# Reenable stuff in case we are rerunning this script.

--- a/provision-contest/disable-turboboost_ht
+++ b/provision-contest/disable-turboboost_ht
@@ -5,7 +5,7 @@ shopt -s extglob
 
 declare -A core_ids
 
-# shellcheck disable SC2012
+# shellcheck disable=SC2012
 for cpu in $(ls -1d /sys/devices/system/cpu/cpu* | sort --version-sort) ; do
 	[[ $(basename $cpu) =~ ^cpu[0-9]+$ ]] || continue
 

--- a/provision-contest/disable-turboboost_ht
+++ b/provision-contest/disable-turboboost_ht
@@ -1,4 +1,4 @@
-bin/bash
+#!/bin/bash
 set -eu -o pipefail
 
 shopt -s extglob

--- a/provision-contest/disable-turboboost_ht
+++ b/provision-contest/disable-turboboost_ht
@@ -1,10 +1,11 @@
-#!/bin/bash
+bin/bash
 set -eu -o pipefail
 
 shopt -s extglob
 
 declare -A core_ids
 
+# shellcheck disable SC2012
 for cpu in $(ls -1d /sys/devices/system/cpu/cpu* | sort --version-sort) ; do
 	[[ $(basename $cpu) =~ ^cpu[0-9]+$ ]] || continue
 


### PR DESCRIPTION
This results in a slightly easier to understand outcome.

On CPUs like where there are 8+8 cores with hyperthreading and cpu0 is on the same core as cpu9, cpu1 and cpu10 etc. Since the script went through cpus lexicographically, it did traverse cpu 10-15 before doing 2-9. This resulted in disabling cpus 2-9, while cpu0, cpu1 and cpu 10-15 were online which is very confusing.

Now it sorts things numerically, so goes through them in a more predictable order and the results is more predictable: in this particular case, cpu 0-7 are online, and cpu 8-15 are disabled.
In more general words: the cpu with the lowest number of each core is still online, higher numbers are disabled.