### PR TITLE
Extend key with physical_package_id

### DIFF
--- a/provision-contest/disable-turboboost_ht
+++ b/provision-contest/disable-turboboost_ht
@@ -21,8 +21,14 @@ for cpu in $(ls -1d /sys/devices/system/cpu/cpu* | sort --version-sort) ; do
 		chmod a-w $cpu/cpufreq/scaling_governor
 	fi
 
-	# Disable all but one thread on each core.
-	core_id=$(cat $cpu/topology/core_id $cpu/topology/physical_package_id)
+	# Disable all but one thread on each core. Both core_id and physical_package_id are
+	# numbers it must be ensured that for the following examples are seen as distinct:
+	#  - core_id=1,  physical_package=11
+	#  - core_id=11, physycal_package=1
+	# Simple concatenation would result in the string '111' for both cores. Though `cat`
+	# adds a newline after each file, we do not want to rely on `cat` to always add this
+	# 'delimiter'.
+	core_id=$(cat $cpu/topology/core_id | tr -d '\n')'-'$(cat $cpu/topology/physical_package_id | tr -d '\n')
 	if [[ ${core_ids[$core_id]:-} ]]; then
 		echo 0 > $cpu/online
 	else

--- a/provision-contest/disable-turboboost_ht
+++ b/provision-contest/disable-turboboost_ht
@@ -22,7 +22,7 @@ for cpu in $(ls -1d /sys/devices/system/cpu/cpu* | sort --version-sort) ; do
 	fi
 
 	# Disable all but one thread on each core.
-	core_id=$(cat $cpu/topology/core_id)
+	core_id=$(cat $cpu/topology/core_id $cpu/topology/physical_package_id)
 	if [[ ${core_ids[$core_id]:-} ]]; then
 		echo 0 > $cpu/online
 	else


### PR DESCRIPTION
In multi-cpu machines the script used to disable (most of) the second physical cpu. This is since the `core_id` numbering is seperate for every physical cpu. In a 8+8 layout the `core_id` is in the range of 0-7.

Since the script only checked whether it had seen a core-id it will disable the entire second physical cpu. By adding the `physical_package_id` this problem is eliminated.