### PR TITLE
Configure judgehost on AWS

### DIFF
--- a/provision-contest/ansible/group_vars/all/all.yml.example
+++ b/provision-contest/ansible/group_vars/all/all.yml.example
@@ -27,6 +27,9 @@ ICPC_IMAGE: false
 # Set this to true when you are using a graphical desktop
 GRAPHICAL: false
 
+# Set this to true when you use an (ICPC) AWS machine
+AWS: true
+
 # Set this when on the blue network at the World Finals where no
 # internet access is available and "packages" must be used as APT repo
 # server.

--- a/provision-contest/ansible/roles/judgedaemon/tasks/main.yml
+++ b/provision-contest/ansible/roles/judgedaemon/tasks/main.yml
@@ -54,6 +54,21 @@
     regexp: '^GRUB_CMDLINE_LINUX_DEFAULT='
     line: "GRUB_CMDLINE_LINUX_DEFAULT=\"{{ procline }}\""
 
+- name: Pre-generate the kernel flags for ansible usage (specific AWS)
+  # AWS machines overwrite the variable from the last step in another file
+  # console: https://tldp.org/HOWTO/Remote-Serial-Console-HOWTO/configure-kernel.html
+  # nvme_core: https://docs.aws.amazon.com/ebs/latest/userguide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
+  when: AWS
+  set_fact:
+    procline_aws: "console=tty1 console=ttyS0 nvme_core.io_timeout=4294967295 {{ procline }}"
+
+- name: Add cgroup kernel parameters for AWS machines
+  when: AWS
+  lineinfile:
+    dest: /etc/default/grub.d/50-cloudimg-settings.cfg
+    regexp: '^GRUB_CMDLINE_LINUX_DEFAULT='
+    line: "GRUB_CMDLINE_LINUX_DEFAULT=\"{{ procline_aws }}\""
+
 - name: Check cgroup kernel parameters
   command: cat /proc/cmdline
   register: kernel_cmdline


### PR DESCRIPTION
This is also a good example for people on Digital Ocean etc.

I think we actually need neither of those extra kernel options but leaving the machine similar to how we got it should lead to a more stable (or easier to debug) machine.