### PR TITLE
Allow setting the SENTRY_DNS

### DIFF
--- a/provision-contest/ansible/group_vars/all/secret.yml.example
+++ b/provision-contest/ansible/group_vars/all/secret.yml.example
@@ -66,3 +66,6 @@ CDS_CONTESTS:
       password: admin
 
 PRESCLIENT_CONTEST: nwerc18
+
+# Sentry DSN URL
+# SENTRY_DSN:

--- a/provision-contest/ansible/roles/domserver/tasks/main.yml
+++ b/provision-contest/ansible/roles/domserver/tasks/main.yml
@@ -112,3 +112,14 @@
   loop:
     - nginx
     - php{{ php_version.stdout }}-fpm
+
+- name: Send errors to Sentry
+  lineinfile:
+    regexp: '^SENTRY_DSN='
+    state: present
+    line: "SENTRY_DSN={{ SENTRY_DSN | default('') }}"
+    dest: "{{ DJ_DIR }}/webapp/.env.local"
+    create: true
+    mode: 0664
+    group: domjudge
+    owner: domjudge


### PR DESCRIPTION
As we use our contests to test `main` most of the time we should gather all encountered errors often, this makes this a bit easier.