### PR TITLE
Don't install texlive on judgehosts

### DIFF
--- a/provision-contest/ansible/roles/base_packages/defaults/main.yml
+++ b/provision-contest/ansible/roles/base_packages/defaults/main.yml
@@ -36,8 +36,6 @@ INSTALLED_PACKAGES:
   - libjsoncpp-dev
   - libmagic-dev
   - debootstrap
-  - texlive-latex-recommended
-  - texlive-latex-extra
   - apache2-utils
   - tig
   - bat

--- a/provision-contest/ansible/roles/domserver/defaults/main.yml
+++ b/provision-contest/ansible/roles/domserver/defaults/main.yml
@@ -2,3 +2,5 @@ DOMSERVER_PACKAGES:
   - nginx
   - php-fpm
   - php-intl
+  - texlive-latex-recommended
+  - texlive-latex-extra


### PR DESCRIPTION
We only need those on the domservers (& admin machines).