### PR TITLE
Remove unneeded variables

### DIFF
--- a/provision-contest/ansible/group_vars/all/secret.yml.example
+++ b/provision-contest/ansible/group_vars/all/secret.yml.example
@@ -4,10 +4,6 @@
 # Adding `strong` in the template will create longer passwords and is used for the
 # passwords which almost never need to be manually typed.
 
-# Password for the MySQL replication user.
-# Set this to enable master-master replication between two domservers.
-#REPLICATION_PASSWORD: {some-strong-replication-password}
-
 # Database user password.
 DB_PASSWORD: {some-strong-database-password}
 
@@ -23,49 +19,6 @@ ADMIN_PASSWORD: {some-admin-password}
 # Set this to enable a password on the 'domjudge' shell accounts
 # created on the domserver and judgehosts.
 #DJ_SHELL_USER_PW: {some-hashed-password}
-
-# Accounts to create when setting up the CDS
-CDS_ACCOUNTS:
-    - username: admin
-      password: {some-adm1n-password}
-      type: admin
-    - username: presAdmin
-      password: {some-presentation-adm1n-password}
-      type: admin
-    - username: presentation
-      password: {some-public-presentation-password}
-      type: public
-    #- username: blue
-    #  password: blu3
-    #  type: staff
-    #- username: balloon
-    #  password: balloonPr1nter
-    #  type: balloon
-    #- username: public
-    #  password: publ1c
-    #  type: public
-    #- username: myicpc
-    #  password: my1cpc
-    #  type: spectator
-    #- username: live
-    #  password: l1ve
-    #  type: analyst
-    #- username: team1
-    #  password: t3am
-    #  type: team
-    #  team_id: 1
-
-# Contest(s) to configure in the CDS
-CDS_CONTESTS:
-  - path: nwerc18 # Path in the contest directory
-    ccs:
-      id: nwerc18 # ID of the contest if hosted at DOMJUDGE_URL
-      # Or provide a absolute URL
-      # url: https://www.domjudge.org/demoweb/api/contests/nwerc18
-      username: admin
-      password: admin
-
-PRESCLIENT_CONTEST: nwerc18
 
 # Sentry DSN URL
 # SENTRY_DSN:


### PR DESCRIPTION
The replication password is set lower in the wf46/wf47 as besides the risk for leaking the database we would also setup replication on the analyst instance.
The ICPC-tools variables are not relevant here as we at this point don't setup the CDS.