### PR TITLE
The WFLuxor blue network has DNS now

### DIFF
--- a/provision-contest/ansible/group_vars/all/all.yml.example
+++ b/provision-contest/ansible/group_vars/all/all.yml.example
@@ -34,6 +34,7 @@ AWS: true
 # server.
 WF_RESTRICTED_NETWORK: true
 WF_GREEN: false
+HOSTS_DNS: false
 
 # Static IP address configuration. Uses the ansible_host variable as the static
 # IP address. Only configured if STATIC_IP_ENABLED is true.

--- a/provision-contest/ansible/group_vars/analyst/all.yml.example
+++ b/provision-contest/ansible/group_vars/analyst/all.yml.example
@@ -10,5 +10,6 @@ DOMSERVER_IP: "{{SERVER_IP_PREFIX}}.240"
 # internet access is available and "packages" must be used as APT repo
 # server.
 WF_GREEN: true
+HOSTS_DNS: true
 
 DB_DUMP_PREFIX: analyst

--- a/provision-contest/ansible/roles/base_packages/tasks/main.yml
+++ b/provision-contest/ansible/roles/base_packages/tasks/main.yml
@@ -16,6 +16,7 @@
     notify: Run apt update
 
   - name: Add packages to hosts file
+    when: HOSTS_DNS
     lineinfile:
       dest: /etc/hosts
       line: "{{ HOSTS['packages'] }} packages"

--- a/provision-contest/ansible/roles/hosts/tasks/main.yml
+++ b/provision-contest/ansible/roles/hosts/tasks/main.yml
@@ -6,6 +6,7 @@
     name: "{{ inventory_hostname }}"
 
 - name: Set new hosts file
+  when: HOSTS_DNS
   template:
     src: hosts.j2
     dest: /etc/hosts


### PR DESCRIPTION
We still need to manually set our IP for the different instances for the keepalived (although we could ask the DNS for that value) but this is a start. This is not tested yet but should be relatively simple to test.