### PR TITLE
Install etckeeper and run hourly

### DIFF
--- a/provision-contest/ansible/roles/base_packages/defaults/main.yml
+++ b/provision-contest/ansible/roles/base_packages/defaults/main.yml
@@ -16,6 +16,7 @@ INSTALLED_PACKAGES:
   - debootstrap
   - default-jdk-headless
   - efibootmgr
+  - etckeeper
   - fontconfig
   - g++
   - gcc

--- a/provision-contest/ansible/roles/system_fixes/tasks/main.yml
+++ b/provision-contest/ansible/roles/system_fixes/tasks/main.yml
@@ -65,5 +65,11 @@
         line: 'DNS=8.8.8.8'
       notify: Reboot the machine
 
+- name: Enable etckeeper autocommits every hour
+  file:
+    src: /etc/cron.daily/etckeeper
+    dest: /etc/cron.hourly/etckeeper
+    state: link
+
 - name: Flush handlers
   meta: flush_handlers


### PR DESCRIPTION
This automatically logs all changes made to /etc in git and is useful for debugging purposes, while it doesn't hurt.