### PR TITLE
Include local config snippet from SSH config

### DIFF
--- a/provision-contest/ansible/roles/ssh/files/config
+++ b/provision-contest/ansible/roles/ssh/files/config
@@ -1,5 +1,10 @@
+# This file is managed by ansible, so any changes you make here will
+# get overwritten in the next ansible run. If you want to make local
+# changes, do this in the following include snippet.
+Include ~/.ssh/config-local
+
 # Defaults used if no other host definitions apply.
 # Add more host specific settings above here.
 Host *
-     NoHostAuthenticationForLocalhost yes
-     ForwardAgent yes
+	NoHostAuthenticationForLocalhost yes
+	ForwardAgent yes


### PR DESCRIPTION
This allows both making local changes that do not get overwritten and still distributing changes via ansible.

Note that ideally any specific additions should be done above the include, so that the local snippet can override them.