### PR TITLE
Run keepalived notification scripts as domjudge user

### DIFF
--- a/provision-contest/ansible/roles/keepalived/templates/keepalived.conf.j2
+++ b/provision-contest/ansible/roles/keepalived/templates/keepalived.conf.j2
@@ -11,6 +11,7 @@ vrrp_instance lb_ipv4 {
 		auth_type PASS
 		auth_pass {{REPLICATION_PASSWORD}}
 	}
+	script_user domjudge domjudge
 	notify_backup /home/domjudge/bin/trigger_alert.sh
 	notify_master /home/domjudge/bin/trigger_alert.sh
 	notify_fault /home/domjudge/bin/trigger_alert.sh


### PR DESCRIPTION
This both prevents/fixes some security alerts and also makes sure that the files that the alerting script copies are the right ones.