### PR TITLE
Fix demoweb installation with new composer location

### DIFF
--- a/update_demoweb.sh
+++ b/update_demoweb.sh
@@ -19,7 +19,7 @@ make QUIET=1 maintainer-clean
 make QUIET=1 MAINT_CXFLAGS='-g -O2 -Wall -fPIE -Wformat -Wformat-security' \
 	inplace-conf >/dev/null 2>&1 || true
 make QUIET=1 inplace-install docs >/dev/null 2>&1
-composer auto-scripts >/dev/null 2>&1
+(cd webapp && composer auto-scripts >/dev/null 2>&1)
 
 # Reset database to known good state:
 mysql $MYSQLOPTS "$DBNAME" < domjudge_demo_remove.sql


### PR DESCRIPTION
This was also fixed in the crontab on domjudge.org for various commands. The composer file is now in the webapp folder in the main repo.