### PR TITLE
Simplify variables to be set

### DIFF
--- a/provision-contest/ansible/roles/keepalived/templates/keepalived.conf.j2
+++ b/provision-contest/ansible/roles/keepalived/templates/keepalived.conf.j2
@@ -1,15 +1,15 @@
 vrrp_instance lb_ipv4 {
 	state MASTER
-	interface {{ KEEPALIVED_INTERFACE|default(ansible_facts['default_ipv4']['interface']) }}
+	interface {{ REPLICATION_INTERFACE|default(ansible_facts['default_ipv4']['interface']) }}
 	use_vmac
 	virtual_router_id 32
-	priority {{KEEPALIVED_PRIORITY}}
+	priority {{ KEEPALIVED_PRIORITY }}
 	virtual_ipaddress {
-		{{DOMSERVER_IP}}
+		{{ DOMSERVER_IP }}
 	}
 	authentication {
 		auth_type PASS
-		auth_pass {{REPLICATION_PASSWORD}}
+		auth_pass {{ REPLICATION_PASSWORD }}
 	}
 	script_user domjudge domjudge
 	notify_backup /home/domjudge/bin/trigger_alert.sh


### PR DESCRIPTION
We use the MySQL replication and keepalived together, if we ever have a usecase where we want to replicate the database and IP in a different way we can set that later.

I think even for the setup:

dj-primary: desktop
dj-second: desktop
dj-emerg: laptop

we would still prefer 1 variable and just not set the priority for dj-emerg so that it wouldn't start `keepalived` but would be setup with replication.