### PR TITLE
Document the vendor snapshot

### DIFF
--- a/provision-contest/ansible/README.md
+++ b/provision-contest/ansible/README.md
@@ -43,6 +43,7 @@ There are a few places where additional files should/can be added:
 * SSL certificates and keys under `roles/ssl/files/`.
 * Machine/group specific local packages under `roles/base_packages/files/install-*/`.
 * Judgehost chroot local packages under `roles/judgedaemon/files/install-chroot/`.
+* The vendor dependencies under `roles/domjudge_checkout/files/vendor.tgz`.
 
 ## TODO
 

--- a/provision-contest/ansible/roles/domjudge_checkout/files/.gitignore
+++ b/provision-contest/ansible/roles/domjudge_checkout/files/.gitignore
@@ -1,1 +1,3 @@
 /lib
+/lib-vendor.tgz
+/vendor.tgz


### PR DESCRIPTION
Also removed it from version control as we need to create it every year and have multiple other binaries which we don't version control.