### PR TITLE
Don't upgrade packages with ansible

### DIFF
--- a/provision-contest/ansible/roles/base_packages/tasks/main.yml
+++ b/provision-contest/ansible/roles/base_packages/tasks/main.yml
@@ -42,8 +42,6 @@
 
 - name: Update cache if this is our first run
   apt:
-    upgrade: true
-    update_cache: true
     cache_valid_time: 3600
 
 - name: Flush handlers


### PR DESCRIPTION
This would make the first installation slower and if the `packages` are updated during the WFs we probably want to explicit do the update and see what gets changed.