### PR TITLE
Set DOMserver IPs

### DIFF
--- a/provision-contest/ansible/group_vars/onprem/all.yml.example
+++ b/provision-contest/ansible/group_vars/onprem/all.yml.example
@@ -2,7 +2,7 @@
 DJ_DIR: /opt/domjudge
 
 # Branch to checkout and use.
-DJ_BRANCH: main
+DJ_BRANCH: wfastana
 
 # Whether to force-pull changes to the checkout, overwriting any local changes.
 DJ_FORCE_UPDATE: true
@@ -11,7 +11,7 @@ DJ_FORCE_UPDATE: true
 SERVER_IP_PREFIX: 10.3.3
 
 # IP address of the git server.
-LOCAL_GIT_IP: "{{SERVER_IP_PREFIX}}.207"
+LOCAL_GIT_IP: "{{SERVER_IP_PREFIX}}.209"
 
 # URL and IP of domserver from judgehosts. A hostname 'domserver' with
 # DOMSERVER_IP will be added to the judgehost /etc/hosts file.
@@ -22,18 +22,18 @@ DOMSERVER_SSL_CERT: /etc/ssl/certs/domserver.crt
 DOMSERVER_SSL_KEY: /etc/ssl/private/domserver.key
 
 # Set this to true when you are using the ICPC World Finals Contest Image
-ICPC_IMAGE: false
+ICPC_IMAGE: true
 
 # Set this to true when you are using a graphical desktop
-GRAPHICAL: false
+GRAPHICAL: true
 
 # Set this to true when you use an (ICPC) AWS machine
-AWS: true
+AWS: false
 
 # Set this when on the blue network at the World Finals where no
 # internet access is available and "packages" must be used as APT repo
 # server.
-WF_RESTRICTED_NETWORK: false
+WF_RESTRICTED_NETWORK: true
 WF_GREEN: false
 
 # Static IP address configuration. Uses the ansible_host variable as the static
@@ -55,7 +55,7 @@ HOSTS:
     domjudge-laptop: 10.3.3.200
     pc2:             10.3.3.241
 
-TIMEZONE: "Europe/Amsterdam"
+TIMEZONE: "Asia/Almaty"
 
 PHP_FPM_MAX_CHILDREN: 400
 PHP_FPM_MAX_REQUESTS: 500
@@ -70,30 +70,9 @@ DJ_GIT_REPO: "https://github.com/domjudge/domjudge.git"
 DJ_GIT_REPO_RESTRICTED: "domjudge@{{DJ_GIT_HOST}}:domjudge"
 DJ_GIT_REPO_SCRIPTS: "https://github.com/domjudge/domjudge-scripts.git"
 DJ_GIT_REPO_SCRIPTS_RESTRICTED: "domjudge@{{DJ_GIT_HOST}}:domjudge-scripts-bare"
-CONTEST_REPO: "wf2021"
+CONTEST_REPO: "wfastana"
 
 PHPSTORM_VERSION: 2022.2
 PHPSTORM_FULL_VERSION: 222.4345.15
 
 GRAFANA_MONITORING: false
-
-# Hostname of the CDS. If set, will add an nginx in front of the CDS
-# If not set, will only expose CDS directly
-CDS_HOSTNAME: cds
-CDS_PORT: 80
-CDS_PORT_SECURE: 443
-
-#  CDS SSL cert and key. Only needed when CDS_HOSTNAME is set
-CDS_SSL_CERT: /etc/ssl/certs/cds.crt
-CDS_SSL_KEY: /etc/ssl/private/cds.key
-
-# Hostname of the static scoreboard
-STATIC_SCOREBOARD_HOSTNAME: scoreboard
-
-STATIC_SCOREBOARD_SSL_CERT: /etc/ssl/certs/scoreboard.crt
-STATIC_SCOREBOARD_SSL_KEY: /etc/ssl/private/scoreboard.key
-
-# Block access to the CDS for IPs other than these
-#CDS_IP_FILTER:
-#  - 127.0.0.1-127.0.0.1
-#  - 192.168.0.0-192.168.255.255

--- a/provision-contest/ansible/group_vars/onprem/analyst-domserver
+++ b/provision-contest/ansible/group_vars/onprem/analyst-domserver
@@ -1,0 +1,1 @@
+group_vars/onprem/analyst

--- a/provision-contest/ansible/group_vars/onprem/analyst-judgehost
+++ b/provision-contest/ansible/group_vars/onprem/analyst-judgehost
@@ -1,0 +1,1 @@
+group_vars/onprem/analyst

--- a/provision-contest/ansible/group_vars/onprem/analyst/secret.yml.example
+++ b/provision-contest/ansible/group_vars/onprem/analyst/secret.yml.example
@@ -1,0 +1,37 @@
+# Server VLAN IP prefix.
+SERVER_IP_PREFIX: 172.29.1
+
+# URL and IP of domserver from judgehosts. A hostname 'domserver' with
+# DOMSERVER_IP will be added to the judgehost /etc/hosts file.
+DOMSERVER_IP: "{{SERVER_IP_PREFIX}}.240"
+
+WF_GREEN: true
+
+# Static IP address configuration. Uses the ansible_host variable as the static
+# IP address. Only configured if STATIC_IP_ENABLED is true.
+STATIC_IP_ENABLED: false
+STATIC_IP_NETMASK: 255.255.252.0
+STATIC_IP_GATEWAY: 172.29.0.1
+STATIC_IP_INTERFACE: enp1s0
+
+# Additional entries for the /etc/hosts file.
+HOSTS:
+    cds:             172.29.1.207
+    packages:        172.29.1.209
+    ntp1:            172.29.1.208
+    ntp2:            172.29.1.209
+    nisprint:        172.29.1.211
+    nismaster:       172.29.1.211
+    printsrv:        172.29.1.211
+
+GRAFANA_MONITORING: false
+
+# Password for the MySQL replication user.
+# Set this to enable master-master replication between two domservers.
+#REPLICATION_PASSWORD: {some-strong-replication-password}
+
+# Database user password.
+DB_PASSWORD: {some-strong-database-password}
+
+# Credentials for the judgehost.
+JUDGEHOST_PASSWORD: {some-strong-judgehost-password}

--- a/provision-contest/ansible/group_vars/onprem/secret.yml.example
+++ b/provision-contest/ansible/group_vars/onprem/secret.yml.example
@@ -4,10 +4,6 @@
 # Adding `strong` in the template will create longer passwords and is used for the
 # passwords which almost never need to be manually typed.
 
-# Password for the MySQL replication user.
-# Set this to enable master-master replication between two domservers.
-#REPLICATION_PASSWORD: {some-strong-replication-password}
-
 # Database user password.
 DB_PASSWORD: {some-strong-database-password}
 
@@ -23,49 +19,6 @@ ADMIN_PASSWORD: {some-admin-password}
 # Set this to enable a password on the 'domjudge' shell accounts
 # created on the domserver and judgehosts.
 #DJ_SHELL_USER_PW: {some-hashed-password}
-
-# Accounts to create when setting up the CDS
-CDS_ACCOUNTS:
-    - username: admin
-      password: {some-adm1n-password}
-      type: admin
-    - username: presAdmin
-      password: {some-presentation-adm1n-password}
-      type: admin
-    - username: presentation
-      password: {some-public-presentation-password}
-      type: public
-    #- username: blue
-    #  password: blu3
-    #  type: staff
-    #- username: balloon
-    #  password: balloonPr1nter
-    #  type: balloon
-    #- username: public
-    #  password: publ1c
-    #  type: public
-    #- username: myicpc
-    #  password: my1cpc
-    #  type: spectator
-    #- username: live
-    #  password: l1ve
-    #  type: analyst
-    #- username: team1
-    #  password: t3am
-    #  type: team
-    #  team_id: 1
-
-# Contest(s) to configure in the CDS
-CDS_CONTESTS:
-  - path: nwerc18 # Path in the contest directory
-    ccs:
-      id: nwerc18 # ID of the contest if hosted at DOMJUDGE_URL
-      # Or provide a absolute URL
-      # url: https://www.domjudge.org/demoweb/api/contests/nwerc18
-      username: admin
-      password: admin
-
-PRESCLIENT_CONTEST: nwerc18
 
 # Sentry DSN URL
 # SENTRY_DSN:

--- a/provision-contest/ansible/group_vars/onprem/wfinal-domserver
+++ b/provision-contest/ansible/group_vars/onprem/wfinal-domserver
@@ -1,0 +1,1 @@
+group_vars/onprem/wfinal

--- a/provision-contest/ansible/group_vars/onprem/wfinal-judgehost
+++ b/provision-contest/ansible/group_vars/onprem/wfinal-judgehost
@@ -1,0 +1,1 @@
+group_vars/onprem/wfinal

--- a/provision-contest/ansible/group_vars/onprem/wfinal/secret.yml.example
+++ b/provision-contest/ansible/group_vars/onprem/wfinal/secret.yml.example
@@ -1,0 +1,3 @@
+# Password for the MySQL replication user.
+# Set this to enable master-master replication between two domservers.
+REPLICATION_PASSWORD: {some-strong-replication-password}

--- a/provision-contest/ansible/hosts
+++ b/provision-contest/ansible/hosts
@@ -58,11 +58,11 @@ green-judgehost2     ansible_host=172.29.1.222
 green-judgehost3     ansible_host=172.29.1.223   
 
 [admin]
-domjudge-ccsadmin1 ansible_host=10.3.3.223
-domjudge-ccsadmin2 ansible_host=10.3.3.224
-domjudge-ccsadmin3 ansible_host=10.3.3.225
-domjudge-ccsadmin4 ansible_host=10.3.3.226
-domjudge-ccsadmin5 ansible_host=10.3.3.227
+domjudge-ccsadmin1 ansible_host=10.3.3.224
+domjudge-ccsadmin2 ansible_host=10.3.3.225
+domjudge-ccsadmin3 ansible_host=10.3.3.226
+domjudge-ccsadmin4 ansible_host=10.3.3.227
+domjudge-ccsadmin5 ansible_host=10.3.3.228
 
 [grafana]
 # During the WFs we use one of the ccsadmin machines

--- a/provision-contest/ansible/hosts
+++ b/provision-contest/ansible/hosts
@@ -15,16 +15,17 @@ admin
 online-domserver
 online-judgehost
 
-[domserver]
+[domserver:children]
+wfinal-domserver
+analyst-domserver
+
+[wfinal-domserver]
 # Set EFI_ORDER onsite for faster boot
 #EFI_ORDER='0\,1\,3\,4'
 domjudge-primary     ansible_host=10.3.3.216   KEEPALIVED_PRIORITY=100 
 domjudge-backup      ansible_host=10.3.3.217   KEEPALIVED_PRIORITY=99
-# Discuss if we can have this host dualhomed in blue to make management easier.\
-# Looking at the IP sheet that would mean that our emergency laptop needs to move.
-domjudge-analyst     ansible_host=172.29.1.240
 
-[domserver:children]
+[wfinal-domserver:children]
 emergency
 
 [emergency]
@@ -61,6 +62,11 @@ domjudge-ccsadmin5 ansible_host=10.3.3.227
 # During the WFs we use one of the ccsadmin machines
 # Doesn't matter which (admin) machine but should not be 1 as that runs ansible
 domjudge-ccsadmin2 ansible_host=10.3.3.225
+
+[analyst-domserver]
+# Discuss if we can have this host dualhomed in blue to make management easier.\
+# Looking at the IP sheet that would mean that our emergency laptop needs to move.
+domjudge-analyst     ansible_host=172.29.1.240
 
 [online-domserver]
 online-domserver       ansible_host=192.168.255.255

--- a/provision-contest/ansible/hosts
+++ b/provision-contest/ansible/hosts
@@ -29,7 +29,7 @@ domjudge-backup      ansible_host=10.3.3.217   KEEPALIVED_PRIORITY=99
 emergency
 
 [emergency]
-domjudge-laptop      ansible_host=10.3.3.241
+domjudge-laptop      ansible_host=10.3.3.199
 
 [judgehost:children]
 analyst-judgehost

--- a/provision-contest/ansible/hosts
+++ b/provision-contest/ansible/hosts
@@ -1,0 +1,69 @@
+[all:vars]
+ansible_user=root
+ansible_python_interpreter=/usr/bin/python3
+
+# When moving clients for ad-hoc actions:
+# move them to their own group to keep hosts files on deployed machines in sync.
+
+[onprem:children]
+domserver
+judgehost
+grafana
+admin
+
+[online:children]
+online-domserver
+online-judgehost
+
+[domserver]
+# Set EFI_ORDER onsite for faster boot
+#EFI_ORDER='0\,1\,3\,4'
+domjudge-primary     ansible_host=10.3.3.216   KEEPALIVED_PRIORITY=100 
+domjudge-backup      ansible_host=10.3.3.217   KEEPALIVED_PRIORITY=99
+# Discuss if we can have this host dualhomed in blue to make management easier.\
+# Looking at the IP sheet that would mean that our emergency laptop needs to move.
+domjudge-analyst     ansible_host=172.29.1.240
+
+[domserver:children]
+emergency
+
+[emergency]
+domjudge-laptop      ansible_host=10.3.3.241
+
+[judgehost]
+domjudge-judgehost1  ansible_host=10.2.2.192
+domjudge-judgehost2  ansible_host=10.2.2.193
+domjudge-judgehost3  ansible_host=10.2.2.194
+domjudge-judgehost4  ansible_host=10.2.2.195
+domjudge-judgehost5  ansible_host=10.2.2.196
+domjudge-judgehost6  ansible_host=10.2.2.197
+domjudge-judgehost7  ansible_host=10.2.2.198
+domjudge-judgehost8  ansible_host=10.2.2.199
+domjudge-judgehost9  ansible_host=10.2.2.200
+domjudge-judgehost10 ansible_host=10.2.2.201
+domjudge-judgehost11 ansible_host=10.2.2.202
+domjudge-judgehost12 ansible_host=10.2.2.203
+domjudge-judgehost13 ansible_host=10.2.2.204
+domjudge-judgehost14 ansible_host=10.2.2.205
+domjudge-judgehost15 ansible_host=10.2.2.206
+domjudge-judgehost16 ansible_host=10.2.2.207
+domjudge-judgehost17 ansible_host=10.2.2.208
+domjudge-judgehost18 ansible_host=10.2.2.209
+
+[admin]
+domjudge-ccsadmin1 ansible_host=10.3.3.223
+domjudge-ccsadmin2 ansible_host=10.3.3.224
+domjudge-ccsadmin3 ansible_host=10.3.3.225
+domjudge-ccsadmin4 ansible_host=10.3.3.226
+domjudge-ccsadmin5 ansible_host=10.3.3.227
+
+[grafana]
+# During the WFs we use one of the ccsadmin machines
+# Doesn't matter which (admin) machine but should not be 1 as that runs ansible
+domjudge-ccsadmin2 ansible_host=10.3.3.225
+
+[online-domserver]
+online-domserver       ansible_host=192.168.255.255
+
+[online-judgehost]
+online-judgehost1      ansible_host=192.168.255.255

--- a/provision-contest/ansible/hosts
+++ b/provision-contest/ansible/hosts
@@ -33,8 +33,9 @@ domjudge-laptop      ansible_host=10.3.3.241
 
 [judgehost:children]
 analyst-judgehost
+wfinal-judgehost
 
-[judgehost]
+[wfinal-judgehost]
 domjudge-judgehost1  ansible_host=10.2.2.192
 domjudge-judgehost2  ansible_host=10.2.2.193
 domjudge-judgehost3  ansible_host=10.2.2.194

--- a/provision-contest/ansible/hosts
+++ b/provision-contest/ansible/hosts
@@ -31,6 +31,9 @@ emergency
 [emergency]
 domjudge-laptop      ansible_host=10.3.3.241
 
+[judgehost:children]
+analyst-judgehost
+
 [judgehost]
 domjudge-judgehost1  ansible_host=10.2.2.192
 domjudge-judgehost2  ansible_host=10.2.2.193
@@ -48,8 +51,11 @@ domjudge-judgehost13 ansible_host=10.2.2.204
 domjudge-judgehost14 ansible_host=10.2.2.205
 domjudge-judgehost15 ansible_host=10.2.2.206
 domjudge-judgehost16 ansible_host=10.2.2.207
-domjudge-judgehost17 ansible_host=10.2.2.208
-domjudge-judgehost18 ansible_host=10.2.2.209
+
+[analyst-judgehost]
+green-judgehost1     ansible_host=172.29.1.221   
+green-judgehost2     ansible_host=172.29.1.222   
+green-judgehost3     ansible_host=172.29.1.223   
 
 [admin]
 domjudge-ccsadmin1 ansible_host=10.3.3.223


### PR DESCRIPTION
See Pat's list, I'm not sure about the analyst instance if that is the host `green` or the host `analyst-green`, went with the `analyst-green`.

Onsite we should discuss which machine will be dualhomed or which firewall can be changed so we can manage the analyst instance.

This also requires a split in grouping to make sure that the analyst instance doesn't get a replication setup. It wouldn't hurt but its better to not install extras which are not needed as it opens up the sql server there in green.