### PR TITLE
Make sure tune_cpu gets started

### DIFF
--- a/provision-contest/ansible/roles/judgedaemon/tasks/main.yml
+++ b/provision-contest/ansible/roles/judgedaemon/tasks/main.yml
@@ -102,6 +102,10 @@
   notify:
     - Enable and restart tune_cpu
 
+- name: Enable and restart tune_cpu (flushing as this should always happen even if we fail further)
+  # We need a daemon-reload, so we loose idempotency if we start the service in the next block
+  ansible.builtin.meta: flush_handlers
+
 - name: Copy judgedaemon related systemd unit files
   copy:
     remote_src: true


### PR DESCRIPTION
In the past we could (and did) fail somewhere in the playbook which would result in not handling this notified handler. This also meant that we would not copy the file again on the next run, so didn't kick the handler and also didn't hit the handler on the next run.

The disadvantage here is we might hit other handlers more often if next roles want to hit the same handler.