### PR TITLE
Add option to configure NGINX real ip

### DIFF
--- a/provision-contest/ansible/group_vars/domserver.yml
+++ b/provision-contest/ansible/group_vars/domserver.yml
@@ -1,0 +1,2 @@
+# If set, configure the real_ip_from header in NGINX to trust a proxy
+# FRONT_REVERSE_PROXY: 192.168.0.1

--- a/provision-contest/ansible/roles/domserver/templates/nginx-domjudge-inner.j2
+++ b/provision-contest/ansible/roles/domserver/templates/nginx-domjudge-inner.j2
@@ -69,5 +69,10 @@ add_header X-Content-Type-Options "nosniff";
 add_header X-XSS-Protection "1; mode=block";
 add_header X-Robots-Tag "none" always;
 
+{% if FRONT_REVERSE_PROXY is defined %}
+set_real_ip_from {{ FRONT_REVERSE_PROXY }};
+real_ip_header X-Forwarded-For;
+{% endif %}
+
 error_log /var/log/nginx/domjudge.log;
 access_log /var/log/nginx/domjudge.log dj_access;


### PR DESCRIPTION
In our setup, we need to configure the proxy for IP autologin.

@vmcj As this is only relevant for domserver, I suggest adding a new `group_vars` file instead of cluttering `all`. What do you think?
