### PR TITLE
Document the installation method for our optional telemetry

### DIFF
--- a/make_release.sh
+++ b/make_release.sh
@@ -62,6 +62,7 @@ fi
 
 # Add released tag for revision information:
 sed -i 's/PUBLISHED =.*/PUBLISHED = release/' paths.mk.in
+sed -i "s/INSTALL_METHOD\s*=.*/INSTALL_METHOD    = tarball/" paths.mk.in
 
 make QUIET=1 dist
 

--- a/make_snapshot.sh
+++ b/make_snapshot.sh
@@ -39,6 +39,7 @@ git clone -q --no-checkout --depth 1 "$GITURL" dj-clone
 
 # Add released tag for revision information:
 sed -i "s/PUBLISHED =.*/PUBLISHED = $(date +%Y-%m-%d)/" "$DJDIR/paths.mk.in"
+sed -i "s/INSTALL_METHOD\s*=.*/INSTALL_METHOD    = snapshot/" "$DJDIR/paths.mk.in"
 
 quiet make -C $DJDIR dist
 tar -cf $DJDIR.tar $DJDIR

--- a/new_release_howto.md
+++ b/new_release_howto.md
@@ -4,6 +4,7 @@ on the account `domjudge@vm-domjudge`):
 
  1. Test everything. (duh...)
  1. Commit the correct version number in the `ChangeLog` and `README` files.
+ 1. Change the default installation method in configure.ac to tarball.
  1. Discuss if the current second to last minor version will now be EOL.
  1. Update https://github.com/DOMjudge/domjudge/security/policy to support 2 minor versions, including     the one now being released.
  1. Change the constants `webapp/src/Controller/API/GeneralInfoController.php`
@@ -27,6 +28,7 @@ on the account `domjudge@vm-domjudge`):
     git checkout main
     ```
  1. Update files above to `{version+1}DEV` and commit.
+ 1. Change the default installation method in configure.ac back to git.
  1. On the server the tarball will be built, signed and published.
  1. Update the DOMjudge homepage: commit changes in the `domjudge-scripts`
     repository under `website/` and run `make install` as domjudge@domjudge


### PR DESCRIPTION
I wonder if we should remove the option from the configure script and always do the `sed` trick and set it per target instead of letting the configure script handle it.