### PR TITLE
Suggest new GitlabCI image per DOMjudge version

### DIFF
--- a/new_release_howto.md
+++ b/new_release_howto.md
@@ -49,4 +49,5 @@ on the account `domjudge@vm-domjudge`):
  1. Put debian packages in `/srv/http/domjudge/debian/mini-dinstall/incoming`
     and run as domjudge@domjudge: `mini-dinstall -b`
  1. Send an email to `domjudge-announce@domjudge.org`, announcing the new version and state which versions are supported.
- 1. Add the released branch to the dependabot.yml (https://github.com/DOMjudge/domjudge/blob/main/.github/dependabot.yml)
+ 1. Add the released branch to the dependabot.yml (https://github.com/DOMjudge/domjudge/blob/main/.github/dependabot.yml).
+ 1. Create a new gitlab CI image for the new release.


### PR DESCRIPTION
By creating a new image per release branch we can more easily reproduce tests for backport releases. It does require some useless work besides upgrading the version in the different files.

Alternative is to trigger a gitlabci docker run with a custom tag for that just released version. Not sure what I like best so this is mostly to start the discussion.