### PR TITLE
Check if "TMP" is set in cleanup

### DIFF
--- a/submit_coverity_scan.sh
+++ b/submit_coverity_scan.sh
@@ -80,7 +80,9 @@ export PATH="$PATH:$COVTOOL/bin"
 
 cleanup()
 {
-  rm -f "$TMP"
+  if [ ! -z "${TMP+x}" ]; then
+	  rm -f "$TMP"
+	fi
 
   if [ -n "$GITURL" ] && [ -z "$DEBUG" ]; then
 	  rm -rf "$TEMPDIR"


### PR DESCRIPTION
It seems this is not set so the script is probably terminating before reaching the creation of the "TMP" variable.

This is only a temporary fix as the script is most likely not running all parts we want it to run.

@eldering this should fix the issues that demoweb is down on Sunday but I think the expected html report is not generated at all. Did we ever use this?